### PR TITLE
feat: compute default question count based on selected chords

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/setup/PracticeSetupViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/setup/PracticeSetupViewModel.kt
@@ -1,23 +1,33 @@
 package com.chordquiz.app.ui.screen.setup
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.chordquiz.app.data.model.QuizMode
+import com.chordquiz.app.ui.navigation.PracticeSetupRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import androidx.navigation.toRoute
 import javax.inject.Inject
 
 data class PracticeSetupUiState(
     val mode: QuizMode = QuizMode.DRAW,
-    val questionCount: Int = 10,
+    val questionCount: Int,
     val repeatMissed: Boolean = true
 )
 
 @HiltViewModel
-class PracticeSetupViewModel @Inject constructor() : ViewModel() {
+class PracticeSetupViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(PracticeSetupUiState())
+    private val chordCount =
+        savedStateHandle.toRoute<PracticeSetupRoute>().selectedChordIds.size
+
+    private val _uiState = MutableStateFlow(
+        PracticeSetupUiState(questionCount = computeDefaultQuestionCount(chordCount))
+    )
     val uiState: StateFlow<PracticeSetupUiState> = _uiState.asStateFlow()
 
     fun setMode(mode: QuizMode) {
@@ -25,16 +35,24 @@ class PracticeSetupViewModel @Inject constructor() : ViewModel() {
     }
 
     fun incrementQuestionCount() {
-        val cur = _uiState.value.questionCount
-        if (cur < 30) _uiState.value = _uiState.value.copy(questionCount = cur + 1)
+        _uiState.value = _uiState.value.copy(questionCount = _uiState.value.questionCount + 1)
     }
 
     fun decrementQuestionCount() {
         val cur = _uiState.value.questionCount
-        if (cur > 3) _uiState.value = _uiState.value.copy(questionCount = cur - 1)
+        if (cur > chordCount.coerceAtLeast(1)) {
+            _uiState.value = _uiState.value.copy(questionCount = cur - 1)
+        }
     }
 
     fun setRepeatMissed(repeat: Boolean) {
         _uiState.value = _uiState.value.copy(repeatMissed = repeat)
+    }
+
+    companion object {
+        fun computeDefaultQuestionCount(chordCount: Int): Int {
+            val raw = chordCount.coerceAtLeast(1) * 3
+            return ((raw + 2) / 5) * 5
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Default question count is now computed as nearest multiple of 5 to (chord count × 3)
- Reads selected chords from navigation route via SavedStateHandle
- Minimum is chord count, no maximum cap
- Sets up SavedStateHandle injection for future issue #19 work

## Test plan
- [ ] Verify default question count for various chord selections
- [ ] Test increment/decrement with new min bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)