### PR TITLE
fix: remove edit workflow, simplify group filter behavior

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -27,8 +27,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -108,14 +106,16 @@ fun ChordLibraryScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    if (uiState.selectedChordIds.size >= 2) {
+                    if (uiState.selectedChordIds.size >= 2
+                        && uiState.activeTypeFilter == null
+                        && uiState.activeGroupFilter == null) {
                         OutlinedButton(
                             onClick = {
-                                dialogInitialName = uiState.editingGroup?.toName() ?: ""
+                                dialogInitialName = ""
                                 showSaveDialog = true
                             }
                         ) {
-                            Text(if (uiState.editingGroup != null) "Update" else "Save")
+                            Text("Save")
                         }
                     }
                     Button(
@@ -169,43 +169,16 @@ fun ChordLibraryScreen(
                     )
                     uiState.customGroups.forEach { group ->
                         key(group.id) {
-                            var showMenu by remember { mutableStateOf(false) }
-                            val editingGroupId = uiState.editingGroup?.id
-                            Box {
-                                FilterChip(
-                                    selected = uiState.activeGroupFilter?.id == group.id,
-                                    onClick = { viewModel.setGroupFilter(group) },
-                                    label = { Text(group.toName()) },
-                                    modifier = Modifier.pointerInput(group.id, editingGroupId) {
-                                        detectTapGestures(
-                                            onLongPress = {
-                                                if (editingGroupId == null || editingGroupId == group.id) {
-                                                    showMenu = true
-                                                }
-                                            }
-                                        )
-                                    }
-                                )
-                                DropdownMenu(
-                                    expanded = showMenu,
-                                    onDismissRequest = { showMenu = false }
-                                ) {
-                                    DropdownMenuItem(
-                                        text = { Text("Edit") },
-                                        onClick = {
-                                            showMenu = false
-                                            viewModel.startEdit(group)
-                                        }
-                                    )
-                                    DropdownMenuItem(
-                                        text = { Text("Delete") },
-                                        onClick = {
-                                            showMenu = false
-                                            viewModel.requestDeleteGroup(group)
-                                        }
+                            FilterChip(
+                                selected = uiState.activeGroupFilter?.id == group.id,
+                                onClick = { viewModel.setGroupFilter(group) },
+                                label = { Text(group.toName()) },
+                                modifier = Modifier.pointerInput(group.id) {
+                                    detectTapGestures(
+                                        onLongPress = { viewModel.requestDeleteGroup(group) }
                                     )
                                 }
-                            }
+                            )
                         }
                     }
                     ChordType.entries.forEach { type ->
@@ -215,16 +188,6 @@ fun ChordLibraryScreen(
                             label = { Text(type.displayName) }
                         )
                     }
-                }
-
-                // Stale chord warning
-                if (uiState.staleChordWarning) {
-                    Text(
-                        text = "Some chords in this group are no longer available.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
-                    )
                 }
 
                 // Chord grid
@@ -280,7 +243,7 @@ fun ChordLibraryScreen(
             }
         }
 
-        // --- Naming dialog (Save / Update) ---
+        // --- Naming dialog (Save as New Group) ---
         if (showSaveDialog) {
             val focusRequester = remember { FocusRequester() }
             LaunchedEffect(Unit) {
@@ -294,7 +257,7 @@ fun ChordLibraryScreen(
                     viewModel.clearSaveNameError()
                 },
                 title = {
-                    Text(if (uiState.editingGroup != null) "Update Group" else "Save as New Group")
+                    Text("Save as New Group")
                 },
                 text = {
                     Column {
@@ -331,7 +294,7 @@ fun ChordLibraryScreen(
                         },
                         enabled = groupName.isNotBlank() && uiState.selectedChordIds.size >= 2
                     ) {
-                        Text(if (uiState.editingGroup != null) "Update" else "Save")
+                        Text("Save")
                     }
                 },
                 dismissButton = {
@@ -375,35 +338,15 @@ fun ChordLibraryScreen(
         uiState.deleteConfirmGroup?.let { group ->
             AlertDialog(
                 onDismissRequest = { viewModel.cancelDeleteGroup() },
-                title = { Text("Delete ${group.toName()}?") },
+                title = { Text("Delete group ${group.toName()}?") },
                 confirmButton = {
                     Button(onClick = { viewModel.confirmDeleteGroup() }) {
-                        Text("Yes")
+                        Text("Delete")
                     }
                 },
                 dismissButton = {
                     TextButton(onClick = { viewModel.cancelDeleteGroup() }) {
-                        Text("No")
-                    }
-                }
-            )
-        }
-
-        // --- Discard edit confirmation dialog ---
-        if (uiState.showDiscardEditDialog) {
-            val groupName = uiState.editingGroup?.toName() ?: ""
-            AlertDialog(
-                onDismissRequest = { viewModel.cancelDiscardEdit() },
-                title = { Text("Discard changes?") },
-                text = { Text("Discard changes to \"$groupName\"?") },
-                confirmButton = {
-                    Button(onClick = { viewModel.confirmDiscardEdit() }) {
-                        Text("Yes")
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { viewModel.cancelDiscardEdit() }) {
-                        Text("No")
+                        Text("Cancel")
                     }
                 }
             )

--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryViewModel.kt
@@ -29,10 +29,7 @@ data class ChordLibraryUiState(
     val activeGroupFilter: GroupEntity? = null,
     val customGroups: List<GroupEntity> = emptyList(),
     val isLoading: Boolean = true,
-    val editingGroup: GroupEntity? = null,
-    val staleChordWarning: Boolean = false,
     val deleteConfirmGroup: GroupEntity? = null,
-    val showDiscardEditDialog: Boolean = false,
     val saveNameError: String? = null,
     val showReplaceGroupDialog: Boolean = false,
     val replaceGroupDisplayName: String? = null
@@ -55,7 +52,6 @@ class ChordLibraryViewModel @Inject constructor(
     private val groupFilter = MutableStateFlow<GroupEntity?>(null)
 
     // Held across the async validation → save flow
-    private var pendingFilterChange: (() -> Unit)? = null
     private var pendingSaveName: String? = null
     private var pendingSaveInstrumentId: String? = null
     private var pendingSaveChordIds: List<String>? = null
@@ -69,13 +65,10 @@ class ChordLibraryViewModel @Inject constructor(
                 groupFilter,
                 groupsRepository.getGroupsFlow(instrumentId)
             ) { chords, typeF, groupF, groups ->
-                val existingIds = chords.map { it.id }.toSet()
                 var filtered = chords
-                var stale = false
                 when {
                     groupF != null -> {
                         val groupIds = groupF.chordIdsList()
-                        stale = groupIds.any { it !in existingIds }
                         filtered = chords.filter { it.id in groupIds }
                     }
                     typeF != null -> {
@@ -89,7 +82,6 @@ class ChordLibraryViewModel @Inject constructor(
                     activeTypeFilter = typeF,
                     activeGroupFilter = groupF,
                     customGroups = groups.sortedByDescending { it.createdAt },
-                    staleChordWarning = stale,
                     isLoading = false
                 )
             }.collect {}
@@ -103,51 +95,25 @@ class ChordLibraryViewModel @Inject constructor(
     }
 
     fun setTypeFilter(type: ChordType?) {
-        if (_uiState.value.editingGroup != null) {
-            pendingFilterChange = {
-                groupFilter.value = null
-                typeFilter.value = type
-                _uiState.value = _uiState.value.copy(
-                    editingGroup = null,
-                    showDiscardEditDialog = false,
-                    selectedChordIds = emptySet()
-                )
-            }
-            _uiState.value = _uiState.value.copy(showDiscardEditDialog = true)
-            return
-        }
+        val wasOnGroup = groupFilter.value != null
         groupFilter.value = null
         typeFilter.value = type
+        if (wasOnGroup) {
+            _uiState.value = _uiState.value.copy(selectedChordIds = emptySet())
+        }
     }
 
     fun setGroupFilter(group: GroupEntity?) {
-        val editing = _uiState.value.editingGroup
-        if (editing != null && group?.id != editing.id) {
-            pendingFilterChange = {
-                typeFilter.value = null
-                groupFilter.value = group
-                _uiState.value = _uiState.value.copy(
-                    editingGroup = null,
-                    showDiscardEditDialog = false,
-                    selectedChordIds = emptySet()
-                )
-            }
-            _uiState.value = _uiState.value.copy(showDiscardEditDialog = true)
-            return
+        val wasOnGroup = groupFilter.value != null
+        typeFilter.value = null
+        groupFilter.value = group
+        if (group != null) {
+            val existingIds = _uiState.value.allChords.map { it.id }.toSet()
+            val selected = group.chordIdsList().filter { it in existingIds }.toSet()
+            _uiState.value = _uiState.value.copy(selectedChordIds = selected)
+        } else if (wasOnGroup) {
+            _uiState.value = _uiState.value.copy(selectedChordIds = emptySet())
         }
-        typeFilter.value = null
-        groupFilter.value = group
-    }
-
-    fun startEdit(group: GroupEntity) {
-        val existingIds = _uiState.value.allChords.map { it.id }.toSet()
-        val selectedIds = group.chordIdsList().filter { it in existingIds }.toSet()
-        typeFilter.value = null
-        groupFilter.value = group
-        _uiState.value = _uiState.value.copy(
-            editingGroup = group,
-            selectedChordIds = selectedIds
-        )
     }
 
     fun requestDeleteGroup(group: GroupEntity) {
@@ -163,7 +129,6 @@ class ChordLibraryViewModel @Inject constructor(
                 groupFilter.value = null
                 _uiState.value = _uiState.value.copy(
                     deleteConfirmGroup = null,
-                    editingGroup = null,
                     selectedChordIds = emptySet()
                 )
             } else {
@@ -174,16 +139,6 @@ class ChordLibraryViewModel @Inject constructor(
 
     fun cancelDeleteGroup() {
         _uiState.value = _uiState.value.copy(deleteConfirmGroup = null)
-    }
-
-    fun confirmDiscardEdit() {
-        pendingFilterChange?.invoke()
-        pendingFilterChange = null
-    }
-
-    fun cancelDiscardEdit() {
-        pendingFilterChange = null
-        _uiState.value = _uiState.value.copy(showDiscardEditDialog = false)
     }
 
     fun requestSaveGroup(name: String, instrumentId: String, chordIds: List<String>) {
@@ -203,20 +158,16 @@ class ChordLibraryViewModel @Inject constructor(
         pendingSaveChordIds = chordIds
 
         val prefixedName = "Custom:$trimmed"
-        val editingGroup = _uiState.value.editingGroup
 
         viewModelScope.launch {
             val existing = groupsRepository.findGroupByName(instrumentId, prefixedName)
-            when {
-                existing == null ->
-                    doSaveGroup(trimmed, instrumentId, chordIds)
-                editingGroup != null && existing.id == editingGroup.id ->
-                    doSaveGroup(trimmed, instrumentId, chordIds)
-                else ->
-                    _uiState.value = _uiState.value.copy(
-                        showReplaceGroupDialog = true,
-                        replaceGroupDisplayName = trimmed
-                    )
+            if (existing == null) {
+                doSaveGroup(trimmed, instrumentId, chordIds)
+            } else {
+                _uiState.value = _uiState.value.copy(
+                    showReplaceGroupDialog = true,
+                    replaceGroupDisplayName = trimmed
+                )
             }
         }
     }
@@ -254,34 +205,12 @@ class ChordLibraryViewModel @Inject constructor(
     private suspend fun doSaveGroup(name: String, instrumentId: String, chordIds: List<String>) {
         val prefixedName = "Custom:$name"
         val chordIdsString = chordIds.joinToString(",")
-        val editingGroup = _uiState.value.editingGroup
 
-        // Delete the group being edited (handles rename case)
-        editingGroup?.let { groupsRepository.deleteGroup(it.id) }
-
-        // Delete any other existing group with the same name (overwrite case)
         val existingWithName = groupsRepository.findGroupByName(instrumentId, prefixedName)
-        if (existingWithName != null && existingWithName.id != editingGroup?.id) {
-            groupsRepository.deleteGroup(existingWithName.id)
-        }
+        existingWithName?.let { groupsRepository.deleteGroup(it.id) }
 
-        val newId = groupsRepository.insertGroup(
+        groupsRepository.insertGroup(
             GroupEntity(instrumentId = instrumentId, name = prefixedName, chordIds = chordIdsString)
-        )
-
-        // In edit mode, keep the active filter pointing at the new group
-        if (editingGroup != null) {
-            groupFilter.value = GroupEntity(
-                id = newId,
-                instrumentId = instrumentId,
-                name = prefixedName,
-                chordIds = chordIdsString
-            )
-        }
-
-        _uiState.value = _uiState.value.copy(
-            editingGroup = null,
-            saveNameError = null
         )
         pendingSaveName = null
         pendingSaveInstrumentId = null


### PR DESCRIPTION
## Summary
- Removes the entire edit workflow (long-press → dropdown → Edit entry point, discard-changes dialog, editingGroup state) per the design decisions in #32
- `setGroupFilter()` now auto-selects the group's chords as a pre-fill; switching to any other filter wipes the selection
- Save button is hidden whenever a group or type filter is active (All chip only)
- Long-press on a custom group chip fires the delete dialog directly; delete dialog now uses "Delete / Cancel" and includes "group" in the title
- Stale chord IDs are silently skipped during auto-selection; stale chord warning banner removed

Closes #32

## Test plan
- [ ] Tap a custom group chip → its chords are pre-selected
- [ ] Tap a different group chip → previous selection is wiped, new group's chords are pre-selected
- [ ] Tap All or a type chip while on a group → selection is wiped
- [ ] With ≥2 chords selected and no filter active → Save button appears
- [ ] With ≥2 chords selected but a group or type filter active → Save button is hidden
- [ ] Long-press a custom group chip → delete confirmation dialog appears with "Delete group <name>?" title and Delete/Cancel buttons
- [ ] Confirm delete while group is active → filter cleared, selection wiped
- [ ] No "Edit" option anywhere in the UI
- [ ] No stale chord warning banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)