### PR TITLE
fix: resolve compile errors from haptic feedback PR (#35)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/haptic/HapticManager.kt
+++ b/app/src/main/java/com/chordquiz/app/haptic/HapticManager.kt
@@ -10,6 +10,7 @@ import com.chordquiz.app.data.preferences.UserPreferencesRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
 
 @Singleton
 class HapticManager @Inject constructor(

--- a/app/src/main/java/com/chordquiz/app/ui/screen/instrument/InstrumentSelectionScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/instrument/InstrumentSelectionScreen.kt
@@ -18,8 +18,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.icons.Icons
-import androidx.compose.material3.icons.filled.Settings
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -46,9 +46,9 @@ fun InstrumentSelectionScreen(
                 title = { Text("Chord Quiz") },
                 scrollBehavior = scrollBehavior,
                 actions = {
-                    androidx.compose.material3.IconButton(onClick = onNavigateToSettings) {
-                        androidx.compose.material3.Icon(
-                            imageVector = androidx.compose.material3.icons.Icons.Default.Settings,
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
                             contentDescription = "Settings"
                         )
                     }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -48,7 +49,6 @@ import com.chordquiz.app.ui.components.chord.InteractiveChordDiagram
 import com.chordquiz.app.ui.screen.settings.SettingsViewModel
 import com.chordquiz.app.ui.theme.CorrectGreen
 import com.chordquiz.app.ui.theme.IncorrectRed
-import android.view.HapticFeedbackConstants
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -88,7 +88,7 @@ fun DrawQuizScreen(
             // Trigger haptic feedback on wrong answer
             LaunchedEffect(state.feedback) {
                 if (state.feedback == AnswerFeedback.INCORRECT && settings.hapticFeedbackEnabled) {
-                    hapticFeedback.performHapticFeedback(HapticFeedbackConstants.ERROR)
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                 }
             }
 

--- a/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsScreen.kt
@@ -19,8 +19,8 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.icons.Icons
-import androidx.compose.material3.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment


### PR DESCRIPTION
## Summary
- Add missing `kotlinx.coroutines.flow.first` import in `HapticManager.kt` (line 29 called `.first()` on a Flow without the import)
- Fix icon imports in `InstrumentSelectionScreen.kt` and `SettingsScreen.kt`: `androidx.compose.material3.icons` → `androidx.compose.material.icons`
- Replace `HapticFeedbackConstants.ERROR` (Android View API) with `HapticFeedbackType.LongPress` (Compose API) in `DrawQuizScreen.kt`

## Test plan
- [ ] Build compiles without errors
- [ ] Settings icon appears in instrument selection screen
- [ ] Back button works in settings screen
- [ ] Haptic feedback triggers on wrong answer in Draw mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)