### PR TITLE
fix: add VIBRATE permission to prevent crash on incorrect answer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:name=".ChordQuizApplication"


### PR DESCRIPTION
## Summary
- `HapticManager.vibrateWrongAnswer()` calls `Vibrator.vibrate()` which requires the `VIBRATE` permission declared in the manifest
- Without it, the system throws a `SecurityException` whenever an incorrect answer is given in Draw mode
- Added `<uses-permission android:name="android.permission.VIBRATE" />` to `AndroidManifest.xml`

## Test plan
- [ ] Build compiles without errors
- [ ] Submitting an incorrect answer in Draw mode no longer crashes the app
- [ ] Haptic feedback vibrates on incorrect answer (when not in silent mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)