### PR TITLE
fix: enable long-press on group FilterChip by adding onTap (#34)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -175,6 +175,7 @@ fun ChordLibraryScreen(
                                 label = { Text(group.toName()) },
                                 modifier = Modifier.pointerInput(group.id) {
                                     detectTapGestures(
+                                        onTap = { viewModel.setGroupFilter(group) },
                                         onLongPress = { viewModel.requestDeleteGroup(group) }
                                     )
                                 }


### PR DESCRIPTION
Closes #34

## Summary
`detectTapGestures` with only `onLongPress` set does not compete properly against `FilterChip`'s internal gesture handling — `onLongPress` never fires. Adding `onTap` lets `detectTapGestures` enter Compose's gesture competition so it can correctly distinguish a tap from a long press.

## Change
One line added in `ChordLibraryScreen.kt`:
```kotlin
onTap = { viewModel.setGroupFilter(group) },
```

## Test plan
- [ ] Build compiles without errors
- [ ] Long-pressing a group chip shows the delete dialog
- [ ] Tapping a group chip still activates the group filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)