### PR TITLE
fix: replace FilterChip with custom chip using combinedClickable for long-press (#34)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -1,8 +1,9 @@
 package com.chordquiz.app.ui.screen.library
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items as gridItems
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -50,7 +52,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -169,16 +171,11 @@ fun ChordLibraryScreen(
                     )
                     uiState.customGroups.forEach { group ->
                         key(group.id) {
-                            FilterChip(
+                            GroupFilterChip(
+                                name = group.toName(),
                                 selected = uiState.activeGroupFilter?.id == group.id,
                                 onClick = { viewModel.setGroupFilter(group) },
-                                label = { Text(group.toName()) },
-                                modifier = Modifier.pointerInput(group.id) {
-                                    detectTapGestures(
-                                        onTap = { viewModel.setGroupFilter(group) },
-                                        onLongPress = { viewModel.requestDeleteGroup(group) }
-                                    )
-                                }
+                                onLongClick = { viewModel.requestDeleteGroup(group) }
                             )
                         }
                     }
@@ -352,5 +349,42 @@ fun ChordLibraryScreen(
                 }
             )
         }
+    }
+}
+
+/**
+ * A chip for custom groups that supports both tap and long-press without gesture conflicts.
+ * Uses [combinedClickable] as the sole gesture handler instead of FilterChip's internal
+ * Surface/selectable, which would compete with an outer pointerInput detector.
+ */
+@Composable
+private fun GroupFilterChip(
+    name: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val containerColor = if (selected) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent
+    val contentColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
+    val borderColor = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.outline
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .clip(CircleShape)
+            .background(containerColor)
+            .border(1.dp, borderColor, CircleShape)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            )
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Text(
+            text = name,
+            style = MaterialTheme.typography.labelLarge,
+            color = contentColor
+        )
     }
 }


### PR DESCRIPTION
Closes #34

## Root cause (updated)
The previous fix (adding `onTap` to `detectTapGestures`) was insufficient. `FilterChip` uses a `Surface` with a `selectable` modifier internally. That internal gesture handler competes with any outer `pointerInput` modifier regardless of which callbacks are registered — `onLongPress` still never fires reliably.

## Fix
Replace `FilterChip` for custom groups with a private `GroupFilterChip` composable built from a plain `Box` + `combinedClickable`. There is now only **one** gesture handler on these chips, so tap and long-press both work as expected.

The "All" and chord-type `FilterChip`s are unchanged.

## Test plan
- [ ] Build compiles without errors
- [ ] Long-pressing a custom group chip shows the delete confirmation dialog
- [ ] Tapping a custom group chip still activates the group filter
- [ ] "All" and chord-type chips are visually and functionally unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)