### PR TITLE
fix: remove unsupported itemVerticalAlignment from FlowRow (#41 follow-up)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -166,8 +166,7 @@ fun ChordLibraryScreen(
                 // Filter chips: All → custom groups (newest first) → preset types
                 FlowRow(
                     modifier = Modifier.padding(horizontal = 12.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    itemVerticalAlignment = Alignment.CenterVertically
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     LibraryFilterChip(
                         label = "All",


### PR DESCRIPTION
The original PR #43 merged with a build-breaking change. This fix removes the unsupported  parameter from FlowRow.

**Fixes:** Compilation error in 