### PR TITLE
feat: add swipe-to-submit gesture for draw quiz (#15)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
@@ -3,11 +3,13 @@ package com.chordquiz.app.ui.screen.quizdraw
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,17 +17,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -33,10 +34,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -49,6 +56,7 @@ import com.chordquiz.app.ui.components.chord.InteractiveChordDiagram
 import com.chordquiz.app.ui.screen.settings.SettingsViewModel
 import com.chordquiz.app.ui.theme.CorrectGreen
 import com.chordquiz.app.ui.theme.IncorrectRed
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -84,6 +92,23 @@ fun DrawQuizScreen(
             // Use displayedQuestion so the chord name doesn't change until Next is pressed
             val question = state.displayedQuestion ?: session.currentQuestion ?: return
             val stringCount = session.instrument.stringCount
+
+            // Swipe-to-submit flash state
+            var showSwipeFlash by remember { mutableStateOf(false) }
+            val flashAlpha by animateFloatAsState(
+                targetValue = if (showSwipeFlash) 0.4f else 0f,
+                animationSpec = tween(
+                    durationMillis = if (showSwipeFlash) 40 else 160,
+                    easing = LinearEasing
+                ),
+                label = "swipeFlash"
+            )
+            LaunchedEffect(showSwipeFlash) {
+                if (showSwipeFlash) {
+                    delay(80)
+                    showSwipeFlash = false
+                }
+            }
 
             // Trigger haptic feedback on wrong answer
             LaunchedEffect(state.feedback) {
@@ -133,18 +158,50 @@ fun DrawQuizScreen(
 
                     // Reset the interactive diagram when the question changes
                     key(state.displayedQuestionIndex) {
-                        InteractiveChordDiagram(
-                            stringCount = stringCount,
-                            initialFingering = state.currentFingering,
-                            incorrectFrettedStrings = state.incorrectFrettedStrings,
-                            incorrectMutedStrings = state.incorrectMutedStrings,
-                            missedMuteStrings = state.missedMuteStrings,
-                            onFingeringChanged = { viewModel.onFingeringChanged(it) },
-                            onNoteSelected = { strIdx, fret -> viewModel.onNoteSelected(strIdx, fret) },
+                        Box(
                             modifier = Modifier
                                 .width(220.dp)
                                 .height(280.dp)
-                        )
+                                .pointerInput(state.feedback == null) {
+                                    // Only active pre-feedback; coroutine is cancelled and re-launched
+                                    // when state.feedback changes, so no double-submit is possible
+                                    if (state.feedback != null) return@pointerInput
+
+                                    var totalDragX = 0f
+                                    detectHorizontalDragGestures(
+                                        onDragStart = { totalDragX = 0f },
+                                        onHorizontalDrag = { change, dragAmount ->
+                                            totalDragX += dragAmount
+                                            change.consume()
+                                        },
+                                        onDragEnd = {
+                                            // PointerInputScope implements Density, so dp.toPx() works directly
+                                            if (totalDragX > 80.dp.toPx()) {
+                                                showSwipeFlash = true
+                                                viewModel.submitAnswer()
+                                            }
+                                            totalDragX = 0f
+                                        },
+                                        onDragCancel = { totalDragX = 0f }
+                                    )
+                                }
+                                .drawWithContent {
+                                    drawContent()
+                                    // White wash overlay — alpha = 0 when not flashing (invisible but always present)
+                                    drawRect(Color.White, size = Size(size.width, size.height), alpha = flashAlpha)
+                                }
+                        ) {
+                            InteractiveChordDiagram(
+                                stringCount = stringCount,
+                                initialFingering = state.currentFingering,
+                                incorrectFrettedStrings = state.incorrectFrettedStrings,
+                                incorrectMutedStrings = state.incorrectMutedStrings,
+                                missedMuteStrings = state.missedMuteStrings,
+                                onFingeringChanged = { viewModel.onFingeringChanged(it) },
+                                onNoteSelected = { strIdx, fret -> viewModel.onNoteSelected(strIdx, fret) },
+                                modifier = Modifier.fillMaxSize()
+                            )
+                        }
                     }
 
                     Text(


### PR DESCRIPTION
Implemented swipe-to-submit gesture for draw quiz screen.

**Changes:**
- Added horizontal drag gesture detection on chord diagram
- Right swipe > 80dp triggers answer submission
- Visual flash feedback (white overlay) on swipe
- Gesture disabled when feedback is shown
- Prevents double-submission via key-based coroutine cancellation

**Closes #15**