### PR TITLE
fix: color open-string dots red when fret errors span open strings

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -160,8 +160,8 @@ fun InteractiveChordDiagram(
                         Offset(x - symbolRadius, symbolY + symbolRadius), 2f)
                 }
                 0 -> {
-                    // Open circle — red if this string should have been muted, black otherwise
-                    val oColor = if (pos.stringIndex in missedMuteStrings) IncorrectRed else Color.Black
+                    // Open circle — red if this string should have been muted or fretted, black otherwise
+                    val oColor = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings) IncorrectRed else Color.Black
                     drawCircle(oColor, symbolRadius, Offset(x, symbolY), style = Stroke(2f))
                 }
             }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizViewModel.kt
@@ -123,7 +123,7 @@ class DrawQuizViewModel @Inject constructor(
                 when {
                     refFret == -1 && userFret != -1 -> missedMuteStrings.add(stringIndex)
                     refFret != -1 && userFret == -1 -> incorrectMutedStrings.add(stringIndex)
-                    refFret > 0 && userFret != refFret -> incorrectFrettedStrings.add(stringIndex)
+                    refFret >= 0 && userFret != refFret -> incorrectFrettedStrings.add(stringIndex)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Expands `incorrectFrettedStrings` condition in `DrawQuizViewModel.kt` from `refFret > 0` to `refFret >= 0`, so when a user frets a string that should be open, it is properly classified as an error
- Updates open-circle color logic in `InteractiveChordDiagram.kt` to also check `incorrectFrettedStrings`, so a string that should be fretted but left open shows a red open circle

## Test plan
- [ ] Answer a chord quiz question by fretting a string that should be open — the finger dot should appear red
- [ ] Answer a chord quiz question by leaving open a string that should be fretted — the open circle should appear red
- [ ] Correctly answered strings should still show normal (non-red) colors
- [ ] Mute-related errors (`missedMuteStrings`, `incorrectMutedStrings`) remain unaffected

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)