### PR TITLE
feat: replace Home button with Back on Results screen

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/navigation/NavGraph.kt
@@ -115,7 +115,26 @@ fun NavGraph() {
                         popUpTo(InstrumentSelectionRoute) { inclusive = true }
                     }
                 },
-                onNavigateBack = { /* Reserved for future use */ },
+                onNavigateBack = {
+                    val instrumentId = SessionStore.lastInstrumentId
+                    val chordIds = SessionStore.lastSelectedChordIds
+                    if (instrumentId != null && chordIds != null) {
+                        val modeStr = if (SessionStore.lastQuizType == "PlayQuizRoute") "PLAY" else "DRAW"
+                        navController.navigate(PracticeSetupRoute(
+                            instrumentId = instrumentId,
+                            selectedChordIds = chordIds,
+                            preserveSettings = true,
+                            initialMode = modeStr,
+                            initialRepeatMissed = SessionStore.lastRepeatMissed
+                        )) {
+                            popUpTo(InstrumentSelectionRoute)
+                        }
+                    } else {
+                        navController.navigate(InstrumentSelectionRoute) {
+                            popUpTo(InstrumentSelectionRoute) { inclusive = true }
+                        }
+                    }
+                },
                 onRestartQuiz = {
                     when (route.restartRoute) {
                         "DrawQuizRoute" -> {

--- a/app/src/main/java/com/chordquiz/app/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/navigation/Routes.kt
@@ -11,7 +11,10 @@ data class ChordLibraryRoute(val instrumentId: String)
 @Serializable
 data class PracticeSetupRoute(
     val instrumentId: String,
-    val selectedChordIds: List<String>
+    val selectedChordIds: List<String>,
+    val preserveSettings: Boolean = false,
+    val initialMode: String = "DRAW",
+    val initialRepeatMissed: Boolean = true
 )
 
 @Serializable

--- a/app/src/main/java/com/chordquiz/app/ui/screen/results/ResultsScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/results/ResultsScreen.kt
@@ -190,9 +190,9 @@ fun ResultsScreen(
                 ) { Text("Try Again") }
 
                 Button(
-                    onClick = onNavigateHome,
+                    onClick = onNavigateBack,
                     modifier = Modifier.weight(1f)
-                ) { Text("Home") }
+                ) { Text("Back") }
             }
         }
     }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/setup/PracticeSetupViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/setup/PracticeSetupViewModel.kt
@@ -22,11 +22,19 @@ class PracticeSetupViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val chordCount =
-        savedStateHandle.toRoute<PracticeSetupRoute>().selectedChordIds.size
+    private val route = savedStateHandle.toRoute<PracticeSetupRoute>()
+    private val chordCount = route.selectedChordIds.size
 
     private val _uiState = MutableStateFlow(
-        PracticeSetupUiState(questionCount = computeDefaultQuestionCount(chordCount))
+        if (route.preserveSettings) {
+            PracticeSetupUiState(
+                mode = QuizMode.valueOf(route.initialMode),
+                repeatMissed = route.initialRepeatMissed,
+                questionCount = computeDefaultQuestionCount(chordCount)
+            )
+        } else {
+            PracticeSetupUiState(questionCount = computeDefaultQuestionCount(chordCount))
+        }
     )
     val uiState: StateFlow<PracticeSetupUiState> = _uiState.asStateFlow()
 


### PR DESCRIPTION
Closes #19

## Summary
- `Routes.kt`: Added `preserveSettings`, `initialMode`, `initialRepeatMissed` optional fields to `PracticeSetupRoute`
- `PracticeSetupViewModel.kt`: Reads route params and conditionally restores mode/repeatMissed while always computing default questionCount
- `NavGraph.kt`: Implemented `onNavigateBack` to navigate to Practice Setup with preserved session settings
- `ResultsScreen.kt`: Bottom button changed from "Home" → "Back" (top-bar house icon unchanged)

## Test plan
- [ ] Complete a Draw quiz → tap Back → verify Practice Setup opens with same chords, same mode (Draw), same repeatMissed, question count at default
- [ ] Complete a Play quiz → tap Back → verify mode is Play
- [ ] Verify top-bar house icon still navigates to Instrument Selection
- [ ] Verify Try Again still works
- [ ] Verify normal Chord Library → Practice Setup flow (no preserveSettings) still starts with all defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)