### PR TITLE
feat: auto-continue after answer in Draw mode

### DIFF
--- a/app/src/main/java/com/chordquiz/app/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/chordquiz/app/data/preferences/UserPreferencesRepository.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.chordquiz.app.data.model.Instrument
@@ -22,6 +23,7 @@ class UserPreferencesRepository @Inject constructor(
 ) {
     private val lastInstrumentKey = stringPreferencesKey("last_instrument_id")
     private val hapticFeedbackKey = booleanPreferencesKey("haptic_feedback_enabled")
+    private val autoContinueDelayKey = intPreferencesKey("auto_continue_delay_seconds")
 
     val lastInstrumentId: Flow<String> = context.dataStore.data
         .map { prefs -> prefs[lastInstrumentKey] ?: Instrument.GUITAR.id }
@@ -29,11 +31,18 @@ class UserPreferencesRepository @Inject constructor(
     val hapticFeedbackEnabled: Flow<Boolean> = context.dataStore.data
         .map { prefs -> prefs[hapticFeedbackKey] ?: true }
 
+    val autoContinueDelaySeconds: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[autoContinueDelayKey] ?: 2 }
+
     suspend fun setLastInstrumentId(id: String) {
         context.dataStore.edit { prefs -> prefs[lastInstrumentKey] = id }
     }
 
     suspend fun setHapticFeedbackEnabled(enabled: Boolean) {
         context.dataStore.edit { prefs -> prefs[hapticFeedbackKey] = enabled }
+    }
+
+    suspend fun setAutoContinueDelaySeconds(seconds: Int) {
+        context.dataStore.edit { prefs -> prefs[autoContinueDelayKey] = seconds }
     }
 }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -92,6 +93,7 @@ fun DrawQuizScreen(
             // Use displayedQuestion so the chord name doesn't change until Next is pressed
             val question = state.displayedQuestion ?: session.currentQuestion ?: return
             val stringCount = session.instrument.stringCount
+            val autoContinueDelayMs = settings.autoContinueDelaySeconds * 1000
 
             // Swipe-to-submit flash state
             var showSwipeFlash by remember { mutableStateOf(false) }
@@ -116,6 +118,23 @@ fun DrawQuizScreen(
                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                 }
             }
+
+            // Auto-advance after delay when feedback is shown
+            LaunchedEffect(state.feedback) {
+                if (state.feedback != null) {
+                    delay(autoContinueDelayMs.toLong())
+                    viewModel.nextQuestion()
+                }
+            }
+
+            val countdownProgress by animateFloatAsState(
+                targetValue = if (state.feedback != null) 0f else 1f,
+                animationSpec = if (state.feedback != null)
+                    tween(durationMillis = autoContinueDelayMs, easing = LinearEasing)
+                else
+                    snap(),
+                label = "countdown"
+            )
 
             Scaffold(
                 topBar = {
@@ -143,6 +162,13 @@ fun DrawQuizScreen(
                         progress = { state.displayedQuestionIndex.toFloat() / session.questions.size },
                         modifier = Modifier.fillMaxWidth()
                     )
+
+                    if (state.feedback != null) {
+                        LinearProgressIndicator(
+                            progress = { countdownProgress },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
 
                     Spacer(Modifier.height(8.dp))
 
@@ -257,14 +283,6 @@ fun DrawQuizScreen(
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             Text("Submit")
-                        }
-                    } else {
-                        Button(
-                            onClick = { viewModel.nextQuestion() },
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            val isLast = state.displayedQuestionIndex + 1 >= session.questions.size
-                            Text(if (isLast) "Finish" else "Next")
                         }
                     }
                 }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizViewModel.kt
@@ -82,6 +82,7 @@ class DrawQuizViewModel @Inject constructor(
 
     fun onFingeringChanged(fingering: Fingering) {
         val state = _uiState.value as? DrawQuizUiState.Active ?: return
+        if (state.feedback != null) return  // locked during countdown
         _uiState.value = state.copy(
             currentFingering = fingering,
             feedback = null,
@@ -92,6 +93,8 @@ class DrawQuizViewModel @Inject constructor(
     }
 
     fun onNoteSelected(stringIndex: Int, fret: Int) {
+        val state = _uiState.value as? DrawQuizUiState.Active ?: return
+        if (state.feedback != null) return  // locked during countdown
         val inst = instrument ?: return
         if (fret < 0) return
         val openNote = inst.openStringNotes.getOrNull(stringIndex) ?: return

--- a/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -73,6 +74,16 @@ fun SettingsScreen(
                 enabled = settings.hapticFeedbackEnabled,
                 onToggle = { viewModel.toggleHapticFeedback(it) }
             )
+            Text(
+                text = "Draw Mode",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(16.dp)
+            )
+            AutoContinueDelayStepper(
+                seconds = settings.autoContinueDelaySeconds,
+                onDecrement = { viewModel.setAutoContinueDelay(settings.autoContinueDelaySeconds - 1) },
+                onIncrement = { viewModel.setAutoContinueDelay(settings.autoContinueDelaySeconds + 1) }
+            )
         }
     }
 }
@@ -108,6 +119,43 @@ fun HapticFeedbackToggle(
     }
 }
 
+@Composable
+fun AutoContinueDelayStepper(
+    seconds: Int,
+    onDecrement: () -> Unit,
+    onIncrement: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text("Auto-continue delay", style = MaterialTheme.typography.bodyLarge)
+            Text(
+                "Time before advancing in Draw mode",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        IconButton(onClick = onDecrement, enabled = seconds > 1) {
+            Text("−", style = MaterialTheme.typography.titleLarge)
+        }
+        Text(
+            "${seconds}s",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.width(32.dp),
+            textAlign = TextAlign.Center
+        )
+        IconButton(onClick = onIncrement, enabled = seconds < 5) {
+            Text("+", style = MaterialTheme.typography.titleLarge)
+        }
+    }
+}
+
 data class Settings(
-    val hapticFeedbackEnabled: Boolean = true
+    val hapticFeedbackEnabled: Boolean = true,
+    val autoContinueDelaySeconds: Int = 2
 )

--- a/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsViewModel.kt
@@ -28,11 +28,22 @@ class SettingsViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(hapticFeedbackEnabled = enabled)
             }
         }
+        viewModelScope.launch {
+            userPreferencesRepository.autoContinueDelaySeconds.collect { delay ->
+                _uiState.value = _uiState.value.copy(autoContinueDelaySeconds = delay)
+            }
+        }
     }
 
     fun toggleHapticFeedback(enabled: Boolean) {
         viewModelScope.launch {
             userPreferencesRepository.setHapticFeedbackEnabled(enabled)
+        }
+    }
+
+    fun setAutoContinueDelay(seconds: Int) {
+        viewModelScope.launch {
+            userPreferencesRepository.setAutoContinueDelaySeconds(seconds.coerceIn(1, 5))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the Next/Finish button with a timed auto-advance (2 s default) after an answer is submitted in Draw mode
- A draining `LinearProgressIndicator` shows countdown progress beneath the quiz progress bar
- Diagram is locked during countdown (taps ignored via guard in ViewModel)
- Fires on last question too, auto-navigating to Results screen

## Settings change
- New **Draw Mode** section in Settings with a stepper (− / +) to configure delay from 1–5 s
- Persisted in DataStore via `UserPreferencesRepository`, survives app restarts

## Test plan
- [ ] Submit correct answer → feedback appears, countdown bar drains, next question loads automatically after delay
- [ ] Submit incorrect answer → feedback + correct fingering shown, countdown bar drains, next question loads
- [ ] Submit answer on last question → auto-navigates to Results after delay
- [ ] Tap diagram strings during countdown → no change (locked)
- [ ] Exit (✕) during countdown → returns home, no phantom navigation
- [ ] Settings → Draw Mode stepper: − disabled at 1 s, + disabled at 5 s
- [ ] Change delay in Settings → quiz respects updated delay

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)