### PR TITLE
fix: move countdown bar below chord diagram

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
@@ -163,13 +163,6 @@ fun DrawQuizScreen(
                         modifier = Modifier.fillMaxWidth()
                     )
 
-                    if (state.feedback != null) {
-                        LinearProgressIndicator(
-                            progress = { countdownProgress },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-
                     Spacer(Modifier.height(8.dp))
 
                     Text("Draw this chord:", style = MaterialTheme.typography.bodyLarge)
@@ -228,6 +221,13 @@ fun DrawQuizScreen(
                                 modifier = Modifier.fillMaxSize()
                             )
                         }
+                    }
+
+                    if (state.feedback != null) {
+                        LinearProgressIndicator(
+                            progress = { countdownProgress },
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
 
                     Text(


### PR DESCRIPTION
## Summary
- Moves the auto-continue countdown `LinearProgressIndicator` from between the quiz progress bar and chord diagram to below the chord diagram

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)