### PR TITLE
fix: always return to All after deleting a custom group

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryViewModel.kt
@@ -123,17 +123,12 @@ class ChordLibraryViewModel @Inject constructor(
     fun confirmDeleteGroup() {
         val group = _uiState.value.deleteConfirmGroup ?: return
         viewModelScope.launch {
-            val wasActive = _uiState.value.activeGroupFilter?.id == group.id
             groupsRepository.deleteGroup(group.id)
-            if (wasActive) {
-                groupFilter.value = null
-                _uiState.value = _uiState.value.copy(
-                    deleteConfirmGroup = null,
-                    selectedChordIds = emptySet()
-                )
-            } else {
-                _uiState.value = _uiState.value.copy(deleteConfirmGroup = null)
-            }
+            groupFilter.value = null
+            _uiState.value = _uiState.value.copy(
+                deleteConfirmGroup = null,
+                selectedChordIds = emptySet()
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- When any custom group is deleted, navigation now always returns to the "All" filter
- Previously only reset to "All" if the deleted group happened to be the active filter

Closes #42

## Test plan
- [ ] Select a custom group filter, delete it → should return to "All"
- [ ] While on "All", delete a custom group → should remain on "All" with selection cleared
- [ ] While on one custom group, delete a different custom group → should return to "All"

🤖 Generated with [Claude Code](https://claude.com/claude-code)