### PR TITLE
feat: show chord preview screen before quiz begins (#21)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/navigation/NavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.toRoute
 import com.chordquiz.app.ui.screen.instrument.InstrumentSelectionScreen
 import com.chordquiz.app.ui.screen.library.ChordLibraryScreen
 import com.chordquiz.app.ui.navigation.ChordLibraryRoute
+import com.chordquiz.app.ui.navigation.ChordPreviewRoute
 import com.chordquiz.app.ui.navigation.DrawQuizRoute
 import com.chordquiz.app.ui.navigation.InstrumentSelectionRoute
 import com.chordquiz.app.ui.navigation.PracticeSetupRoute
@@ -15,6 +16,7 @@ import com.chordquiz.app.ui.navigation.PlayQuizRoute
 import com.chordquiz.app.ui.navigation.ResultsRoute
 import com.chordquiz.app.ui.navigation.SettingsRoute
 import com.chordquiz.app.ui.shared.SessionStore
+import com.chordquiz.app.ui.screen.preview.ChordPreviewScreen
 import com.chordquiz.app.ui.screen.setup.PracticeSetupScreen
 import com.chordquiz.app.ui.screen.quizdraw.DrawQuizScreen
 import com.chordquiz.app.ui.screen.quizplay.PlayQuizScreen
@@ -56,10 +58,26 @@ fun NavGraph() {
                 selectedChordIds = route.selectedChordIds,
                 onNavigateBack = { navController.popBackStack() },
                 onStartDrawQuiz = { instrumentId, chordIds, count, repeat ->
-                    navController.navigate(DrawQuizRoute(instrumentId, chordIds, count, repeat))
+                    navController.navigate(ChordPreviewRoute(instrumentId, chordIds, count, repeat, "draw"))
                 },
                 onStartPlayQuiz = { instrumentId, chordIds, count, repeat ->
-                    navController.navigate(PlayQuizRoute(instrumentId, chordIds, count, repeat))
+                    navController.navigate(ChordPreviewRoute(instrumentId, chordIds, count, repeat, "play"))
+                }
+            )
+        }
+
+        composable<ChordPreviewRoute> { backStackEntry ->
+            val route = backStackEntry.toRoute<ChordPreviewRoute>()
+            ChordPreviewScreen(
+                instrumentId = route.instrumentId,
+                selectedChordIds = route.selectedChordIds,
+                onBack = { navController.popBackStack() },
+                onBegin = {
+                    if (route.quizMode == "play") {
+                        navController.navigate(PlayQuizRoute(route.instrumentId, route.selectedChordIds, route.questionCount, route.repeatMissed))
+                    } else {
+                        navController.navigate(DrawQuizRoute(route.instrumentId, route.selectedChordIds, route.questionCount, route.repeatMissed))
+                    }
                 }
             )
         }
@@ -136,40 +154,21 @@ fun NavGraph() {
                     }
                 },
                 onRestartQuiz = {
-                    when (route.restartRoute) {
-                        "DrawQuizRoute" -> {
-                            SessionStore.lastInstrumentId?.let { instrumentId ->
-                                SessionStore.lastSelectedChordIds?.let { chordIds ->
-                                    navController.navigate(DrawQuizRoute(
-                                        instrumentId = instrumentId,
-                                        selectedChordIds = chordIds,
-                                        questionCount = SessionStore.lastQuestionCount,
-                                        repeatMissed = SessionStore.lastRepeatMissed
-                                    )) {
-                                        popUpTo(InstrumentSelectionRoute)
-                                    }
-                                }
-                            } ?: navController.navigate(InstrumentSelectionRoute) {
-                                popUpTo(InstrumentSelectionRoute) { inclusive = true }
-                            }
+                    val instrumentId = SessionStore.lastInstrumentId
+                    val chordIds = SessionStore.lastSelectedChordIds
+                    if (instrumentId != null && chordIds != null) {
+                        val quizMode = if (route.restartRoute == "PlayQuizRoute") "play" else "draw"
+                        navController.navigate(ChordPreviewRoute(
+                            instrumentId = instrumentId,
+                            selectedChordIds = chordIds,
+                            questionCount = SessionStore.lastQuestionCount,
+                            repeatMissed = SessionStore.lastRepeatMissed,
+                            quizMode = quizMode
+                        )) {
+                            popUpTo(InstrumentSelectionRoute)
                         }
-                        "PlayQuizRoute" -> {
-                            SessionStore.lastInstrumentId?.let { instrumentId ->
-                                SessionStore.lastSelectedChordIds?.let { chordIds ->
-                                    navController.navigate(PlayQuizRoute(
-                                        instrumentId = instrumentId,
-                                        selectedChordIds = chordIds,
-                                        questionCount = SessionStore.lastQuestionCount,
-                                        repeatMissed = SessionStore.lastRepeatMissed
-                                    )) {
-                                        popUpTo(InstrumentSelectionRoute)
-                                    }
-                                }
-                            } ?: navController.navigate(InstrumentSelectionRoute) {
-                                popUpTo(InstrumentSelectionRoute) { inclusive = true }
-                            }
-                        }
-                        else -> navController.navigate(InstrumentSelectionRoute) {
+                    } else {
+                        navController.navigate(InstrumentSelectionRoute) {
                             popUpTo(InstrumentSelectionRoute) { inclusive = true }
                         }
                     }

--- a/app/src/main/java/com/chordquiz/app/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/navigation/Routes.kt
@@ -34,6 +34,15 @@ data class PlayQuizRoute(
 )
 
 @Serializable
+data class ChordPreviewRoute(
+    val instrumentId: String,
+    val selectedChordIds: List<String>,
+    val questionCount: Int,
+    val repeatMissed: Boolean,
+    val quizMode: String // "draw" | "play"
+)
+
+@Serializable
 data class ResultsRoute(val sessionId: String, val restartRoute: String? = null)
 
 @Serializable

--- a/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewScreen.kt
@@ -1,0 +1,250 @@
+package com.chordquiz.app.ui.screen.preview
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chordquiz.app.data.model.ChordDefinition
+import com.chordquiz.app.ui.components.chord.ChordDiagram
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChordPreviewScreen(
+    instrumentId: String,
+    selectedChordIds: List<String>,
+    onBack: () -> Unit,
+    onBegin: () -> Unit,
+    viewModel: ChordPreviewViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(instrumentId, selectedChordIds) {
+        viewModel.initialize(instrumentId, selectedChordIds)
+    }
+
+    BackHandler(onBack = onBack)
+
+    var selectedChordIndex by remember { mutableStateOf<Int?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Chords in This Quiz") })
+        },
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
+            ) {
+                Button(
+                    onClick = onBegin,
+                    modifier = Modifier.align(Alignment.CenterEnd)
+                ) {
+                    Text("Begin  →")
+                }
+            }
+        }
+    ) { innerPadding ->
+        when (val state = uiState) {
+            is ChordPreviewUiState.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is ChordPreviewUiState.Ready -> {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(3),
+                    contentPadding = PaddingValues(
+                        start = 8.dp,
+                        end = 8.dp,
+                        top = innerPadding.calculateTopPadding() + 8.dp,
+                        bottom = innerPadding.calculateBottomPadding() + 8.dp
+                    ),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    itemsIndexed(state.chords) { index, chord ->
+                        ChordPreviewCard(
+                            chord = chord,
+                            onClick = { selectedChordIndex = index }
+                        )
+                    }
+                }
+
+                selectedChordIndex?.let { index ->
+                    ChordDetailModal(
+                        chords = state.chords,
+                        initialIndex = index,
+                        onDismiss = { selectedChordIndex = null }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChordPreviewCard(
+    chord: ChordDefinition,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outlineVariant,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .clickable(onClick = onClick)
+            .padding(4.dp)
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            ChordDiagram(
+                chord = chord,
+                modifier = Modifier.size(width = 80.dp, height = 96.dp)
+            )
+            Text(
+                text = chord.chordName,
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ChordDetailModal(
+    chords: List<ChordDefinition>,
+    initialIndex: Int,
+    onDismiss: () -> Unit
+) {
+    var currentIndex by remember(initialIndex) { mutableIntStateOf(initialIndex) }
+    val chord = chords[currentIndex]
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        title = { Text(chord.chordName, style = MaterialTheme.typography.titleLarge) },
+                        navigationIcon = {
+                            IconButton(onClick = onDismiss) {
+                                Icon(Icons.Default.Close, contentDescription = "Close")
+                            }
+                        }
+                    )
+                },
+                bottomBar = {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        IconButton(
+                            onClick = { if (currentIndex > 0) currentIndex-- },
+                            enabled = currentIndex > 0
+                        ) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Previous")
+                        }
+                        Text(
+                            "${currentIndex + 1} / ${chords.size}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.align(Alignment.CenterVertically)
+                        )
+                        IconButton(
+                            onClick = { if (currentIndex < chords.size - 1) currentIndex++ },
+                            enabled = currentIndex < chords.size - 1
+                        ) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = "Next")
+                        }
+                    }
+                }
+            ) { innerPadding ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = chord.chordName,
+                        style = MaterialTheme.typography.displayMedium
+                    )
+
+                    Spacer(Modifier.height(24.dp))
+
+                    ChordDiagram(
+                        chord = chord,
+                        modifier = Modifier.fillMaxWidth(0.75f)
+                    )
+
+                    Spacer(Modifier.height(24.dp))
+
+                    Text(
+                        text = chord.noteComponents.joinToString(" · ") { it.displayName },
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewViewModel.kt
@@ -1,0 +1,36 @@
+package com.chordquiz.app.ui.screen.preview
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chordquiz.app.data.model.ChordDefinition
+import com.chordquiz.app.data.repository.ChordRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed class ChordPreviewUiState {
+    object Loading : ChordPreviewUiState()
+    data class Ready(val chords: List<ChordDefinition>) : ChordPreviewUiState()
+}
+
+@HiltViewModel
+class ChordPreviewViewModel @Inject constructor(
+    private val chordRepo: ChordRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ChordPreviewUiState>(ChordPreviewUiState.Loading)
+    val uiState: StateFlow<ChordPreviewUiState> = _uiState.asStateFlow()
+
+    fun initialize(instrumentId: String, selectedChordIds: List<String>) {
+        viewModelScope.launch {
+            val allChords = chordRepo.getChordsForInstrument(instrumentId).first()
+            val selectedIdSet = selectedChordIds.toSet()
+            val filtered = allChords.filter { it.id in selectedIdSet }
+            _uiState.value = ChordPreviewUiState.Ready(filtered)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new **Chord Preview** screen between PracticeSetup and the quiz (both Draw and Play modes)
- Displays all selected chords as a scrollable 3-column grid of name + fingering diagram
- Tapping any chord opens a **full-screen modal** with a large diagram, note components (e.g. *A · C · E · G*), and previous/next navigation
- Fixed "Begin →" button at the bottom launches the quiz; system back returns to PracticeSetup
- Preview also appears when tapping "Try Again" from the Results screen

## Test plan

- [ ] Select chords, tap Start Quiz → Preview screen appears with all selected chords in grid
- [ ] Tap a chord card → full-screen modal opens with large diagram, chord name, note components
- [ ] Previous/Next buttons navigate through all chords; disabled at ends
- [ ] System back from Preview → returns to PracticeSetup
- [ ] Tap Begin → quiz starts correctly in Draw mode
- [ ] Tap Begin → quiz starts correctly in Play mode
- [ ] Complete a quiz, tap "Try Again" → Preview screen appears again before restarting
- [ ] Large chord set (10+) → grid scrolls correctly, Begin button stays fixed

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)