### PR TITLE
Fix up-neck chord diagram rendering

### DIFF
--- a/app/src/main/java/com/chordquiz/app/data/db/ChordQuizDatabase.kt
+++ b/app/src/main/java/com/chordquiz/app/data/db/ChordQuizDatabase.kt
@@ -12,7 +12,7 @@ import com.chordquiz.app.data.db.entity.InstrumentEntity
 
 @Database(
     entities = [InstrumentEntity::class, ChordDefinitionEntity::class, GroupEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 abstract class ChordQuizDatabase : RoomDatabase() {

--- a/app/src/main/java/com/chordquiz/app/data/db/dao/ChordDao.kt
+++ b/app/src/main/java/com/chordquiz/app/data/db/dao/ChordDao.kt
@@ -21,6 +21,9 @@ interface ChordDao {
     @Query("SELECT COUNT(*) FROM chords WHERE instrumentId = :instrumentId")
     suspend fun countForInstrument(instrumentId: String): Int
 
+    @Query("SELECT COUNT(*) FROM chords")
+    suspend fun count(): Int
+
     @Query("SELECT * FROM chords WHERE instrumentId = :instrumentId AND id = :chordId")
     suspend fun getChordById(instrumentId: String, chordId: String): ChordDefinitionEntity?
 

--- a/app/src/main/java/com/chordquiz/app/data/seed/BanjoChords.kt
+++ b/app/src/main/java/com/chordquiz/app/data/seed/BanjoChords.kt
@@ -30,7 +30,8 @@ object BanjoChords {
             rootNote = root,
             chordType = type,
             fingerings = fingeringData.map { (positions, barre) ->
-                Fingering(positions = positions, barre = barre)
+                val baseFret = positions.filter { it.fret > 0 }.minOfOrNull { it.fret } ?: 1
+                Fingering(positions = positions, barre = barre, baseFret = baseFret)
             },
             noteComponents = notes
         )

--- a/app/src/main/java/com/chordquiz/app/data/seed/BassChords.kt
+++ b/app/src/main/java/com/chordquiz/app/data/seed/BassChords.kt
@@ -27,7 +27,8 @@ object BassChords {
             rootNote = root,
             chordType = type,
             fingerings = fingeringData.map { (positions, barre) ->
-                Fingering(positions = positions, barre = barre)
+                val baseFret = positions.filter { it.fret > 0 }.minOfOrNull { it.fret } ?: 1
+                Fingering(positions = positions, barre = barre, baseFret = baseFret)
             },
             noteComponents = notes
         )

--- a/app/src/main/java/com/chordquiz/app/data/seed/GuitarChords.kt
+++ b/app/src/main/java/com/chordquiz/app/data/seed/GuitarChords.kt
@@ -27,7 +27,8 @@ object GuitarChords {
             rootNote = root,
             chordType = type,
             fingerings = fingeringData.map { (positions, barre) ->
-                Fingering(positions = positions, barre = barre)
+                val baseFret = positions.filter { it.fret > 0 }.minOfOrNull { it.fret } ?: 1
+                Fingering(positions = positions, barre = barre, baseFret = baseFret)
             },
             noteComponents = notes
         )

--- a/app/src/main/java/com/chordquiz/app/data/seed/UkuleleChords.kt
+++ b/app/src/main/java/com/chordquiz/app/data/seed/UkuleleChords.kt
@@ -26,7 +26,8 @@ object UkuleleChords {
             rootNote = root,
             chordType = type,
             fingerings = fingeringData.map { (positions, barre) ->
-                Fingering(positions = positions, barre = barre)
+                val baseFret = positions.filter { it.fret > 0 }.minOfOrNull { it.fret } ?: 1
+                Fingering(positions = positions, barre = barre, baseFret = baseFret)
             },
             noteComponents = notes
         )

--- a/app/src/main/java/com/chordquiz/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/chordquiz/app/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.chordquiz.app.di
 import android.content.Context
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.chordquiz.app.data.db.ChordQuizDatabase
 import com.chordquiz.app.data.db.dao.ChordDao
@@ -26,22 +27,34 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
 
+    private val MIGRATION_3_4 = object : Migration(3, 4) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("DELETE FROM chords")
+        }
+    }
+
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): ChordQuizDatabase {
         var database: ChordQuizDatabase? = null
 
         val callback = object : RoomDatabase.Callback() {
-            override fun onCreate(db: SupportSQLiteDatabase) {
-                super.onCreate(db)
+            override fun onCreate(db: SupportSQLiteDatabase) { seedIfEmpty() }
+            override fun onOpen(db: SupportSQLiteDatabase) { seedIfEmpty() }
+
+            private fun seedIfEmpty() {
                 CoroutineScope(Dispatchers.IO).launch {
                     database?.let { db ->
-                        db.instrumentDao().insertAll(
-                            Instrument.ALL.map { InstrumentEntity.fromDomain(it) }
-                        )
-                        db.chordDao().insertAll(
-                            ChordLibrary.ALL.map { ChordDefinitionEntity.fromDomain(it) }
-                        )
+                        if (db.instrumentDao().count() == 0) {
+                            db.instrumentDao().insertAll(
+                                Instrument.ALL.map { InstrumentEntity.fromDomain(it) }
+                            )
+                        }
+                        if (db.chordDao().count() == 0) {
+                            db.chordDao().insertAll(
+                                ChordLibrary.ALL.map { ChordDefinitionEntity.fromDomain(it) }
+                            )
+                        }
                     }
                 }
             }
@@ -51,7 +64,8 @@ object DatabaseModule {
             context,
             ChordQuizDatabase::class.java,
             "chord_quiz.db"
-        ).addCallback(callback)
+        ).addMigrations(MIGRATION_3_4)
+            .addCallback(callback)
             .build()
             .also { database = it }
     }

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -37,7 +37,7 @@ fun ChordDiagram(
     val fingering = chord.fingerings.getOrElse(fingeringIndex) { chord.fingerings.first() }
     ChordDiagramCanvas(
         fingering = fingering,
-        stringCount = chord.fingerings.first().positions.size,
+        stringCount = fingering.positions.size,
         modifier = modifier
     )
 }
@@ -69,34 +69,37 @@ fun ChordDiagramCanvas(
         val bottomPad = size.height * 0.04f
         val leftPad = size.width * 0.14f
         val rightPad = size.width * 0.06f
+        val baseFret = fingering.baseFret
+        val fretLabelExtra = if (baseFret > 1) size.width * 0.06f else 0f
+        val effectiveLeftPad = leftPad + fretLabelExtra
 
-        val diagramWidth = size.width - leftPad - rightPad
+        val diagramWidth = size.width - effectiveLeftPad - rightPad
         val diagramHeight = size.height - topPad - bottomPad
 
-        val stringSpacing = diagramWidth / (stringCount - 1)
+        // Use actual position count for spacing calculation
+        val actualStringCount = fingering.positions.size
+        val stringSpacing = diagramWidth / (if (actualStringCount > 1) actualStringCount - 1 else 1)
         val fretSpacing = diagramHeight / displayedFrets
-
-        val baseFret = fingering.baseFret
 
         // Draw nut or fret number
         if (baseFret == 1) {
             drawRect(
                 color = nutColor,
-                topLeft = Offset(leftPad, topPad - fretSpacing * 0.12f),
+                topLeft = Offset(effectiveLeftPad, topPad - fretSpacing * 0.12f),
                 size = Size(diagramWidth, fretSpacing * 0.12f)
             )
         } else {
+            val labelText = "$baseFret"
+            val labelStyle = TextStyle(color = Color.Black, fontSize = (size.height * 0.07f / density).sp)
+            val measured = textMeasurer.measure(labelText, style = labelStyle)
             drawText(
                 textMeasurer = textMeasurer,
-                text = "${baseFret}fr",
+                text = labelText,
                 topLeft = Offset(
-                    leftPad - size.width * 0.12f,
-                    topPad + fretSpacing * 0.3f
+                    x = effectiveLeftPad - size.width * 0.12f,
+                    y = topPad - measured.size.height / 2f
                 ),
-                style = TextStyle(
-                    color = Color.Black,
-                    fontSize = (size.height * 0.07f / density).sp
-                )
+                style = labelStyle
             )
         }
 
@@ -105,15 +108,15 @@ fun ChordDiagramCanvas(
             val y = topPad + f * fretSpacing
             drawLine(
                 color = Color.Gray,
-                start = Offset(leftPad, y),
-                end = Offset(leftPad + diagramWidth, y),
+                start = Offset(effectiveLeftPad, y),
+                end = Offset(effectiveLeftPad + diagramWidth, y),
                 strokeWidth = if (f == 0 && baseFret == 1) 0f else 1.5f
             )
         }
 
         // Draw string lines
         for (s in 0 until stringCount) {
-            val x = leftPad + s * stringSpacing
+            val x = effectiveLeftPad + s * stringSpacing
             drawLine(
                 color = stringLineColor,
                 start = Offset(x, topPad),
@@ -126,7 +129,7 @@ fun ChordDiagramCanvas(
         val symbolY = topPad - fretSpacing * 0.45f
         val symbolRadius = size.width * 0.035f
         fingering.positions.forEach { pos ->
-            val x = leftPad + pos.stringIndex * stringSpacing
+            val x = effectiveLeftPad + pos.stringIndex * stringSpacing
             when {
                 pos.fret == -1 -> {
                     // Muted X
@@ -146,8 +149,8 @@ fun ChordDiagramCanvas(
         // Draw barre
         fingering.barre?.let { barre ->
             val y = topPad + (barre.fret - baseFret + 0.5f) * fretSpacing
-            val x1 = leftPad + barre.fromString * stringSpacing
-            val x2 = leftPad + barre.toString * stringSpacing
+            val x1 = effectiveLeftPad + barre.fromString * stringSpacing
+            val x2 = effectiveLeftPad + barre.toString * stringSpacing
             val barreRadius = fretSpacing * 0.35f
             drawRoundRect(
                 color = barreColor,
@@ -161,7 +164,7 @@ fun ChordDiagramCanvas(
         fingering.positions
             .filter { it.fret > 0 }
             .forEach { pos ->
-                val x = leftPad + pos.stringIndex * stringSpacing
+                val x = effectiveLeftPad + pos.stringIndex * stringSpacing
                 val y = topPad + (pos.fret - baseFret + 0.5f) * fretSpacing
                 drawCircle(dotColor, fretSpacing * 0.35f, Offset(x, y))
             }

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -52,6 +52,7 @@ fun InteractiveChordDiagram(
     onNoteSelected: ((stringIndex: Int, fret: Int) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
+    val effectiveBaseFret = initialFingering?.baseFret ?: baseFret
     val initialPositions = initialFingering?.positions
         ?: (0 until stringCount).map { StringPosition(it, 0) }
 
@@ -63,6 +64,7 @@ fun InteractiveChordDiagram(
 
     var topPad = 0f
     var leftPad = 0f
+    var effectiveLeftPad = 0f
     var stringSpacing = 0f
     var fretSpacing = 0f
     var diagramHeight = 0f
@@ -75,7 +77,7 @@ fun InteractiveChordDiagram(
                 detectTapGestures { offset ->
                     if (stringSpacing == 0f) return@detectTapGestures
 
-                    val rawString = ((offset.x - leftPad) / stringSpacing).toInt()
+                    val rawString = ((offset.x - effectiveLeftPad) / stringSpacing).toInt()
                     val tappedString = rawString.coerceIn(0, stringCount - 1)
 
                     if (offset.y < topPad) {
@@ -86,14 +88,14 @@ fun InteractiveChordDiagram(
                             val idx = list.indexOfFirst { it.stringIndex == tappedString }
                             if (idx >= 0) list[idx] = StringPosition(tappedString, newFret)
                         }
-                        onFingeringChanged(Fingering(positions.toList(), baseFret = baseFret))
+                        onFingeringChanged(Fingering(positions.toList(), baseFret = effectiveBaseFret))
                         if (newFret == 0) onNoteSelected?.invoke(tappedString, 0)
                         return@detectTapGestures
                     }
 
                     // Fret grid tap
-                    val rawFret = ((offset.y - topPad) / fretSpacing).toInt() + baseFret
-                    val tappedFret = rawFret.coerceIn(baseFret, baseFret + displayedFrets - 1)
+                    val rawFret = ((offset.y - topPad) / fretSpacing).toInt() + effectiveBaseFret
+                    val tappedFret = rawFret.coerceIn(effectiveBaseFret, effectiveBaseFret + displayedFrets - 1)
                     val curPos = positions.firstOrNull { it.stringIndex == tappedString }
                     val newFret = if (curPos?.fret == tappedFret) 0 else tappedFret
 
@@ -102,7 +104,7 @@ fun InteractiveChordDiagram(
                         if (idx >= 0) list[idx] = StringPosition(tappedString, newFret)
                         else list.add(StringPosition(tappedString, newFret))
                     }
-                    onFingeringChanged(Fingering(positions.toList(), baseFret = baseFret))
+                    onFingeringChanged(Fingering(positions.toList(), baseFret = effectiveBaseFret))
                     if (newFret > 0) onNoteSelected?.invoke(tappedString, newFret)
                 }
             }
@@ -111,37 +113,45 @@ fun InteractiveChordDiagram(
         val bottomPad = size.height * 0.04f
         leftPad = size.width * 0.14f
         val rightPad = size.width * 0.06f
+        val fretLabelExtra = if (effectiveBaseFret > 1) size.width * 0.06f else 0f
+        effectiveLeftPad = leftPad + fretLabelExtra
 
-        val diagramWidth = size.width - leftPad - rightPad
+        val diagramWidth = size.width - effectiveLeftPad - rightPad
         diagramHeight = size.height - topPad - bottomPad
         stringSpacing = diagramWidth / (stringCount - 1)
         fretSpacing = diagramHeight / displayedFrets
 
         // Nut / fret number
-        if (baseFret == 1) {
+        if (effectiveBaseFret == 1) {
             drawRect(
                 color = NutBrown,
-                topLeft = Offset(leftPad, topPad - fretSpacing * 0.12f),
+                topLeft = Offset(effectiveLeftPad, topPad - fretSpacing * 0.12f),
                 size = Size(diagramWidth, fretSpacing * 0.12f)
             )
         } else {
+            val labelText = "$effectiveBaseFret"
+            val labelStyle = TextStyle(color = Color.Black, fontSize = (size.height * 0.07f / density).sp)
+            val measured = textMeasurer.measure(labelText, style = labelStyle)
             drawText(
                 textMeasurer = textMeasurer,
-                text = "${baseFret}fr",
-                topLeft = Offset(leftPad - size.width * 0.12f, topPad + fretSpacing * 0.3f),
-                style = TextStyle(color = Color.Black, fontSize = (size.height * 0.07f / density).sp)
+                text = labelText,
+                topLeft = Offset(
+                    x = effectiveLeftPad - size.width * 0.12f,
+                    y = topPad - measured.size.height / 2f
+                ),
+                style = labelStyle
             )
         }
 
         // Fret lines
         for (f in 0..displayedFrets) {
             val y = topPad + f * fretSpacing
-            drawLine(Color.Gray, Offset(leftPad, y), Offset(leftPad + diagramWidth, y), 1.5f)
+            drawLine(Color.Gray, Offset(effectiveLeftPad, y), Offset(effectiveLeftPad + diagramWidth, y), 1.5f)
         }
 
         // String lines
         for (s in 0 until stringCount) {
-            val x = leftPad + s * stringSpacing
+            val x = effectiveLeftPad + s * stringSpacing
             drawLine(StringColor, Offset(x, topPad), Offset(x, topPad + diagramHeight), 1.5f)
         }
 
@@ -149,7 +159,7 @@ fun InteractiveChordDiagram(
         val symbolY = topPad - fretSpacing * 0.45f
         val symbolRadius = size.width * 0.035f
         positions.forEach { pos ->
-            val x = leftPad + pos.stringIndex * stringSpacing
+            val x = effectiveLeftPad + pos.stringIndex * stringSpacing
             when (pos.fret) {
                 -1 -> {
                     // Muted X — red if incorrectly muted, gray otherwise
@@ -169,8 +179,8 @@ fun InteractiveChordDiagram(
 
         // Finger dots
         positions.filter { it.fret > 0 }.forEach { pos ->
-            val x = leftPad + pos.stringIndex * stringSpacing
-            val y = topPad + (pos.fret - baseFret + 0.5f) * fretSpacing
+            val x = effectiveLeftPad + pos.stringIndex * stringSpacing
+            val y = topPad + (pos.fret - effectiveBaseFret + 0.5f) * fretSpacing
             val dotColor = if (pos.stringIndex in incorrectFrettedStrings) IncorrectRed else FingerDot
             drawCircle(dotColor, fretSpacing * 0.35f, Offset(x, y))
         }
@@ -178,7 +188,7 @@ fun InteractiveChordDiagram(
         // Faint tap-target hint grid
         for (s in 0 until stringCount) {
             for (f in 0 until displayedFrets) {
-                val cx = leftPad + s * stringSpacing
+                val cx = effectiveLeftPad + s * stringSpacing
                 val cy = topPad + (f + 0.5f) * fretSpacing
                 drawCircle(Color.Gray.copy(alpha = 0.15f), fretSpacing * 0.3f, Offset(cx, cy))
             }


### PR DESCRIPTION
## Summary
- Auto-computes `baseFret` in all 4 seed files (guitar, bass, ukulele, banjo) as the minimum non-muted, non-open fret value, so high-fret voicings no longer default to `baseFret = 1`
- Adds `effectiveLeftPad` in both `ChordDiagram` and `InteractiveChordDiagram` to shift the fretboard right when `baseFret > 1`, giving the fret label room in the left margin
- Renders the fret label as just the number (e.g. `"8"` not `"8fr"`), centered vertically on the top fret line
- Bumps DB version 3 → 4 with a migration that clears stale chord rows; updates the Room callback to re-seed on `onOpen` (idempotent) so existing users get fresh data on next launch

## Test plan
- [ ] C major high voicing (barre at fret 8) shows "8" label aligned with top fret, nut absent, barre in first cell
- [ ] Standard open chords (E, G, etc.) visually unchanged — nut visible, no extra left margin
- [ ] Bass, ukulele, banjo high-fret chords render correctly
- [ ] DB upgrade v3 → v4 wipes and re-seeds chords without data loss for other tables

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)