### PR TITLE
Fix: only shift baseFret up neck when max fret exceeds 5-fret window

### DIFF
--- a/app/src/main/java/com/chordquiz/app/data/db/ChordQuizDatabase.kt
+++ b/app/src/main/java/com/chordquiz/app/data/db/ChordQuizDatabase.kt
@@ -12,7 +12,7 @@ import com.chordquiz.app.data.db.entity.InstrumentEntity
 
 @Database(
     entities = [InstrumentEntity::class, ChordDefinitionEntity::class, GroupEntity::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class ChordQuizDatabase : RoomDatabase() {

--- a/app/src/main/java/com/chordquiz/app/data/seed/BanjoChords.kt
+++ b/app/src/main/java/com/chordquiz/app/data/seed/BanjoChords.kt
@@ -30,7 +30,9 @@ object BanjoChords {
             rootNote = root,
             chordType = type,
             fingerings = fingeringData.map { (positions, barre) ->
-                val baseFret = positions.filter { it.fret > 0 }.minOfOrNull { it.fret } ?: 1
+                val fretted = positions.filter { it.fret > 0 }
+                val baseFret = if ((fretted.maxOfOrNull { it.fret } ?: 0) > 5)
+                    fretted.minOfOrNull { it.fret } ?: 1 else 1
                 Fingering(positions = positions, barre = barre, baseFret = baseFret)
             },
             noteComponents = notes

--- a/app/src/main/java/com/chordquiz/app/data/seed/BassChords.kt
+++ b/app/src/main/java/com/chordquiz/app/data/seed/BassChords.kt
@@ -27,7 +27,9 @@ object BassChords {
             rootNote = root,
             chordType = type,
             fingerings = fingeringData.map { (positions, barre) ->
-                val baseFret = positions.filter { it.fret > 0 }.minOfOrNull { it.fret } ?: 1
+                val fretted = positions.filter { it.fret > 0 }
+                val baseFret = if ((fretted.maxOfOrNull { it.fret } ?: 0) > 5)
+                    fretted.minOfOrNull { it.fret } ?: 1 else 1
                 Fingering(positions = positions, barre = barre, baseFret = baseFret)
             },
             noteComponents = notes

--- a/app/src/main/java/com/chordquiz/app/data/seed/GuitarChords.kt
+++ b/app/src/main/java/com/chordquiz/app/data/seed/GuitarChords.kt
@@ -27,7 +27,9 @@ object GuitarChords {
             rootNote = root,
             chordType = type,
             fingerings = fingeringData.map { (positions, barre) ->
-                val baseFret = positions.filter { it.fret > 0 }.minOfOrNull { it.fret } ?: 1
+                val fretted = positions.filter { it.fret > 0 }
+                val baseFret = if ((fretted.maxOfOrNull { it.fret } ?: 0) > 5)
+                    fretted.minOfOrNull { it.fret } ?: 1 else 1
                 Fingering(positions = positions, barre = barre, baseFret = baseFret)
             },
             noteComponents = notes

--- a/app/src/main/java/com/chordquiz/app/data/seed/UkuleleChords.kt
+++ b/app/src/main/java/com/chordquiz/app/data/seed/UkuleleChords.kt
@@ -26,7 +26,9 @@ object UkuleleChords {
             rootNote = root,
             chordType = type,
             fingerings = fingeringData.map { (positions, barre) ->
-                val baseFret = positions.filter { it.fret > 0 }.minOfOrNull { it.fret } ?: 1
+                val fretted = positions.filter { it.fret > 0 }
+                val baseFret = if ((fretted.maxOfOrNull { it.fret } ?: 0) > 5)
+                    fretted.minOfOrNull { it.fret } ?: 1 else 1
                 Fingering(positions = positions, barre = barre, baseFret = baseFret)
             },
             noteComponents = notes

--- a/app/src/main/java/com/chordquiz/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/chordquiz/app/di/DatabaseModule.kt
@@ -33,6 +33,12 @@ object DatabaseModule {
         }
     }
 
+    private val MIGRATION_4_5 = object : Migration(4, 5) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("DELETE FROM chords")
+        }
+    }
+
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): ChordQuizDatabase {
@@ -64,7 +70,7 @@ object DatabaseModule {
             context,
             ChordQuizDatabase::class.java,
             "chord_quiz.db"
-        ).addMigrations(MIGRATION_3_4)
+        ).addMigrations(MIGRATION_3_4, MIGRATION_4_5)
             .addCallback(callback)
             .build()
             .also { database = it }


### PR DESCRIPTION
## Summary
- Corrects the `baseFret` calculation introduced in #59: `baseFret` now stays `1` (nut visible) unless the chord's maximum fretted note exceeds `displayedFrets` (5), in which case `baseFret = min fretted note`
- Fixes the regression where near-nut chords like ukulele C (only fret 3) were incorrectly rendered away from the nut with a fret-number label
- Bumps DB version 4 → 5 with a chords-table wipe so existing users receive corrected `baseFret` values on next launch

## Test plan
- [ ] Ukulele C chord (fret 3 only) shows nut, no fret-number label
- [ ] Guitar C major high voicing (frets 8–10) still shows "8" label, no nut
- [ ] All standard open/near-nut chords across guitar, bass, ukulele, banjo unchanged
- [ ] DB upgrade 4 → 5 re-seeds correctly

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)