### PR TITLE
fix: move Continue countdown below instructions in Draw mode

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
@@ -223,19 +223,19 @@ fun DrawQuizScreen(
                         }
                     }
 
-                    if (state.feedback != null) {
-                        LinearProgressIndicator(
-                            progress = { countdownProgress },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-
                     Text(
                         "Tap strings/frets to place fingers\nTap above nut to toggle open/muted\nDrag right-to-left along a fret to draw a barre",
                         style = MaterialTheme.typography.bodySmall,
                         textAlign = TextAlign.Center,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+
+                    if (state.feedback != null) {
+                        LinearProgressIndicator(
+                            progress = { countdownProgress },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
 
                     // Feedback banner
                     AnimatedVisibility(


### PR DESCRIPTION
## Summary
- Moves the countdown timer (LinearProgressIndicator) to appear below the instructions text in Draw mode
- Improves visual hierarchy by grouping feedback elements together

## Test plan
- [ ] Start a Draw mode quiz
- [ ] Submit an answer
- [ ] Verify the countdown timer appears below the instructions text
- [ ] Verify the countdown is above the feedback banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)