### PR TITLE
fix: remove note components from chord preview modal

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewScreen.kt
@@ -235,14 +235,6 @@ private fun ChordDetailModal(
                         chord = chord,
                         modifier = Modifier.fillMaxWidth(0.75f)
                     )
-
-                    Spacer(Modifier.height(24.dp))
-
-                    Text(
-                        text = chord.noteComponents.joinToString(" · ") { it.displayName },
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
Removes the chord notes display (A · C · E · G) from the ChordDetailModal in the chord preview screen.

## Changes
- Removed the `Spacer` and `Text` components that displayed note components below the chord diagram
- The `Arrangement.Center` is kept so content remains vertically centered
- All data structures (`noteComponents`) and business logic remain unchanged

## Test Plan
- [ ] Navigate to chord preview screen
- [ ] Tap any chord card to open the modal
- [ ] Verify modal shows chord name (large text), diagram, and navigation
- [ ] Verify no notes text appears below the diagram
- [ ] Verify content is vertically centered
- [ ] Navigate between chords using Previous/Next buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)