### PR TITLE
fix: initialize draw diagram at target chord's baseFret (#67)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -57,7 +57,9 @@ fun InteractiveChordDiagram(
     onNoteSelected: ((stringIndex: Int, fret: Int) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
-    val effectiveBaseFret = initialFingering?.baseFret ?: baseFret
+    var effectiveBaseFret by remember {
+        mutableStateOf(initialFingering?.baseFret ?: baseFret)
+    }
     val initialPositions = initialFingering?.positions
         ?: (0 until stringCount).map { StringPosition(it, 0) }
 
@@ -195,6 +197,23 @@ fun InteractiveChordDiagram(
                                 // Left-to-right drag (or above-nut drag) → let bubble to parent
                                 break
                             }
+                        }
+
+                        // Classify once vertical movement reaches one full fret spacing
+                        if (!gestureClassified &&
+                            kotlin.math.abs(dy) >= fretSpacing &&
+                            kotlin.math.abs(dy) > kotlin.math.abs(dx)
+                        ) {
+                            gestureClassified = true
+                            val delta = if (dy < 0) 1 else -1  // swipe up → higher up neck
+                            val newBase = (effectiveBaseFret + delta).coerceAtLeast(1)
+                            if (newBase != effectiveBaseFret) {
+                                effectiveBaseFret = newBase
+                                barre = null
+                                positions = (0 until stringCount).map { StringPosition(it, 0) }.toMutableList()
+                                onFingeringChanged(Fingering(positions.toList(), null, newBase))
+                            }
+                            break
                         }
 
                         if (isBarreDrag) {

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizViewModel.kt
@@ -71,10 +71,13 @@ class DrawQuizViewModel @Inject constructor(
             if (selected.isEmpty()) return@launch
 
             val session = buildSession(inst, QuizMode.DRAW, selected, questionCount, repeatMissed)
+            val firstQuestion = session.questions.firstOrNull()
+            val firstBaseFret = firstQuestion?.chordDefinition?.fingerings
+                ?.getOrNull(firstQuestion.targetFingeringIndex)?.baseFret ?: 1
             _uiState.value = DrawQuizUiState.Active(
                 session = session,
-                currentFingering = emptyFingering(inst.stringCount),
-                displayedQuestion = session.questions.firstOrNull(),
+                currentFingering = emptyFingering(inst.stringCount, firstBaseFret),
+                displayedQuestion = firstQuestion,
                 displayedQuestionIndex = 0
             )
         }
@@ -172,19 +175,23 @@ class DrawQuizViewModel @Inject constructor(
             SessionStore.save(state.session)
             _uiState.value = DrawQuizUiState.Complete(state.session.id)
         } else {
+            val nextQuestion = state.session.currentQuestion
+            val nextBaseFret = nextQuestion?.chordDefinition?.fingerings
+                ?.getOrNull(nextQuestion.targetFingeringIndex)?.baseFret ?: 1
             _uiState.value = state.copy(
-                currentFingering = emptyFingering(inst.stringCount),
+                currentFingering = emptyFingering(inst.stringCount, nextBaseFret),
                 feedback = null,
                 incorrectFrettedStrings = emptySet(),
                 incorrectMutedStrings = emptySet(),
                 missedMuteStrings = emptySet(),
-                displayedQuestion = state.session.currentQuestion,
+                displayedQuestion = nextQuestion,
                 displayedQuestionIndex = state.displayedQuestionIndex + 1
             )
         }
     }
 
-    private fun emptyFingering(stringCount: Int) = Fingering(
-        positions = (0 until stringCount).map { StringPosition(it, 0) }
+    private fun emptyFingering(stringCount: Int, baseFret: Int = 1) = Fingering(
+        positions = (0 until stringCount).map { StringPosition(it, 0) },
+        baseFret = baseFret
     )
 }


### PR DESCRIPTION
## Summary
- `emptyFingering()` now accepts a `baseFret` parameter; both call sites (initial load and next-question reset) pass the target fingering's `baseFret` so the draw diagram opens at the same fret as the display diagram
- `effectiveBaseFret` in `InteractiveChordDiagram` is now mutable state, enabling swipe up/down to scroll the neck position (swipe up = higher up neck, swipe down = lower; clearing placed dots/barres on scroll)

## Test plan
- [ ] Open Draw quiz with an up-neck chord (e.g. a guitar chord with `baseFret > 1`); confirm the empty draw diagram starts at the same fret shown in the display diagram
- [ ] Swipe up on the draw diagram; confirm `baseFret` increments, fret number label updates, and existing dots are cleared
- [ ] Swipe down; confirm `baseFret` decrements (minimum 1, nut appears at fret 1)
- [ ] Confirm taps and right-to-left barre drags still work correctly after a swipe
- [ ] Submit a correct answer; confirm next question resets diagram to its target `baseFret`
- [ ] Submit an incorrect answer and retry; confirm diagram resets to target `baseFret`

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)