### PR TITLE
fix: cap scroll at instrument fret limit and persist notes on scroll (#71)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/data/model/Instrument.kt
+++ b/app/src/main/java/com/chordquiz/app/data/model/Instrument.kt
@@ -17,14 +17,16 @@ data class Instrument(
             displayName = "Guitar",
             stringCount = 6,
             openStringNotes = listOf(Note.E, Note.A, Note.D, Note.G, Note.B, Note.E),
-            openStringOctaves = listOf(2, 2, 3, 3, 3, 4)
+            openStringOctaves = listOf(2, 2, 3, 3, 3, 4),
+            totalFrets = 20
         )
         val UKULELE = Instrument(
             id = "ukulele_soprano",
             displayName = "Ukulele",
             stringCount = 4,
             openStringNotes = listOf(Note.G, Note.C, Note.E, Note.A),
-            openStringOctaves = listOf(4, 4, 4, 4)
+            openStringOctaves = listOf(4, 4, 4, 4),
+            totalFrets = 12
         )
         val BASS = Instrument(
             id = "bass_standard",

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -49,6 +49,7 @@ fun InteractiveChordDiagram(
     stringCount: Int,
     displayedFrets: Int = 5,
     baseFret: Int = 1,
+    totalFrets: Int = 21,
     initialFingering: Fingering? = null,
     incorrectFrettedStrings: Set<Int> = emptySet(),
     incorrectMutedStrings: Set<Int> = emptySet(),
@@ -206,12 +207,11 @@ fun InteractiveChordDiagram(
                         ) {
                             gestureClassified = true
                             val delta = if (dy < 0) 1 else -1  // swipe up → higher up neck
-                            val newBase = (effectiveBaseFret + delta).coerceAtLeast(1)
+                            val maxBaseFret = (totalFrets - displayedFrets + 1).coerceAtLeast(1)
+                            val newBase = (effectiveBaseFret + delta).coerceIn(1, maxBaseFret)
                             if (newBase != effectiveBaseFret) {
                                 effectiveBaseFret = newBase
-                                barre = null
-                                positions = (0 until stringCount).map { StringPosition(it, 0) }.toMutableList()
-                                onFingeringChanged(Fingering(positions.toList(), null, newBase))
+                                onFingeringChanged(Fingering(positions.toList(), barre, newBase))
                             }
                             break
                         }
@@ -340,8 +340,10 @@ fun InteractiveChordDiagram(
             }
         }
 
+        val visibleRange = effectiveBaseFret..(effectiveBaseFret + displayedFrets - 1)
+
         // Barre (drawn before finger dots so dots render on top)
-        barre?.let { b ->
+        barre?.takeIf { it.fret in visibleRange }?.let { b ->
             val y = topPad + (b.fret - effectiveBaseFret + 0.5f) * fretSpacing
             val x1 = effectiveLeftPad + b.fromString * stringSpacing
             val x2 = effectiveLeftPad + b.toString * stringSpacing
@@ -355,7 +357,7 @@ fun InteractiveChordDiagram(
         }
 
         // Finger dots
-        positions.filter { it.fret > 0 }.forEach { pos ->
+        positions.filter { it.fret > 0 && it.fret in visibleRange }.forEach { pos ->
             val x = effectiveLeftPad + pos.stringIndex * stringSpacing
             val y = topPad + (pos.fret - effectiveBaseFret + 0.5f) * fretSpacing
             val dotColor = if (pos.stringIndex in incorrectFrettedStrings) IncorrectRed else FingerDot

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
@@ -212,6 +212,7 @@ fun DrawQuizScreen(
                         ) {
                             InteractiveChordDiagram(
                                 stringCount = stringCount,
+                                totalFrets = session.instrument.totalFrets,
                                 initialFingering = state.currentFingering,
                                 incorrectFrettedStrings = state.incorrectFrettedStrings,
                                 incorrectMutedStrings = state.incorrectMutedStrings,


### PR DESCRIPTION
## Summary
- Set `totalFrets = 20` for Guitar and `totalFrets = 12` for Ukulele in `Instrument.kt` (Bass 24 and Banjo 22 were already correct)
- `InteractiveChordDiagram` now receives `totalFrets` and caps scroll at `maxBaseFret = totalFrets − displayedFrets + 1`, preventing scrolling past the last real fret
- Positions and barre are no longer cleared on scroll — they persist in the model and reappear when scrolling back into range
- Dot and barre rendering filters to the visible fret window so off-screen notes are hidden but not lost

## Test plan
- [ ] Guitar: scroll up neck; confirm scrolling stops when the bottom of the diagram reaches fret 20
- [ ] Ukulele: confirm scrolling stops at fret 12
- [ ] Banjo: confirm scrolling stops at fret 22; Bass at fret 24
- [ ] Place notes at fret 5, scroll up past them, scroll back down — confirm notes reappear
- [ ] Draw a barre, scroll past it, scroll back — confirm barre reappears
- [ ] Confirm taps, barre drags, and note toggling still work normally after scrolling

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)