### PR TITLE
feat: add optional notes on fretboard (closes #11)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/data/model/ChordDefinition.kt
+++ b/app/src/main/java/com/chordquiz/app/data/model/ChordDefinition.kt
@@ -1,5 +1,7 @@
 package com.chordquiz.app.data.model
 
+import com.chordquiz.app.domain.model.NoteDisplayMode
+
 data class ChordDefinition(
     val id: String,
     val instrumentId: String,
@@ -12,4 +14,7 @@ data class ChordDefinition(
     val noteComponents: List<Note>
 ) {
     val displayName: String get() = "${rootNote.displayName}${chordType.suffix}"
+
+    fun displayName(mode: NoteDisplayMode): String =
+        "${rootNote.displayNameFor(mode)}${chordType.suffix}"
 }

--- a/app/src/main/java/com/chordquiz/app/data/model/Note.kt
+++ b/app/src/main/java/com/chordquiz/app/data/model/Note.kt
@@ -1,5 +1,7 @@
 package com.chordquiz.app.data.model
 
+import com.chordquiz.app.domain.model.NoteDisplayMode
+
 enum class Note(val semitone: Int, val displayName: String, val flatName: String? = null) {
     C(0, "C"),
     C_SHARP(1, "C#", "Db"),
@@ -15,6 +17,11 @@ enum class Note(val semitone: Int, val displayName: String, val flatName: String
     B(11, "B");
 
     fun plus(semitones: Int): Note = fromSemitone(semitone + semitones)
+
+    fun displayNameFor(mode: NoteDisplayMode, octave: Int? = null): String {
+        val base = if (mode.useFlats()) flatName ?: displayName else displayName
+        return if (mode.showOctave() && octave != null) "$base$octave" else base
+    }
 
     companion object {
         fun fromSemitone(s: Int): Note = entries[s.mod(12)]

--- a/app/src/main/java/com/chordquiz/app/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/chordquiz/app/data/preferences/UserPreferencesRepository.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.chordquiz.app.data.model.Instrument
 import com.chordquiz.app.domain.model.Difficulty
+import com.chordquiz.app.domain.model.NoteDisplayMode
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -26,6 +27,7 @@ class UserPreferencesRepository @Inject constructor(
     private val hapticFeedbackKey = booleanPreferencesKey("haptic_feedback_enabled")
     private val autoContinueDelayKey = intPreferencesKey("auto_continue_delay_seconds")
     private val difficultyKey = stringPreferencesKey("difficulty")
+    private val noteDisplayModeKey = stringPreferencesKey("note_display_mode")
 
     val lastInstrumentId: Flow<String> = context.dataStore.data
         .map { prefs -> prefs[lastInstrumentKey] ?: Instrument.GUITAR.id }
@@ -38,6 +40,9 @@ class UserPreferencesRepository @Inject constructor(
 
     val difficulty: Flow<Difficulty> = context.dataStore.data
         .map { prefs -> prefs[difficultyKey]?.let { runCatching { Difficulty.valueOf(it) }.getOrNull() } ?: Difficulty.DEFAULT }
+
+    val noteDisplayMode: Flow<NoteDisplayMode> = context.dataStore.data
+        .map { prefs -> prefs[noteDisplayModeKey]?.let { runCatching { NoteDisplayMode.valueOf(it) }.getOrNull() } ?: NoteDisplayMode.NONE }
 
     suspend fun setLastInstrumentId(id: String) {
         context.dataStore.edit { prefs -> prefs[lastInstrumentKey] = id }
@@ -53,5 +58,9 @@ class UserPreferencesRepository @Inject constructor(
 
     suspend fun setDifficulty(difficulty: Difficulty) {
         context.dataStore.edit { prefs -> prefs[difficultyKey] = difficulty.name }
+    }
+
+    suspend fun setNoteDisplayMode(mode: NoteDisplayMode) {
+        context.dataStore.edit { prefs -> prefs[noteDisplayModeKey] = mode.name }
     }
 }

--- a/app/src/main/java/com/chordquiz/app/domain/model/NoteDisplayMode.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/model/NoteDisplayMode.kt
@@ -1,0 +1,13 @@
+package com.chordquiz.app.domain.model
+
+enum class NoteDisplayMode {
+    NONE,         // ◌
+    SHARP,        // C#
+    FLAT,         // Bb
+    SHARP_OCTAVE, // C#4
+    FLAT_OCTAVE;  // Bb4
+
+    fun showNotes(): Boolean = this != NONE
+    fun useFlats(): Boolean = this == FLAT || this == FLAT_OCTAVE
+    fun showOctave(): Boolean = this == SHARP_OCTAVE || this == FLAT_OCTAVE
+}

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.chordquiz.app.data.model.BarreSegment
 import com.chordquiz.app.data.model.Fingering
+import com.chordquiz.app.data.model.Note
 import com.chordquiz.app.data.model.StringPosition
+import com.chordquiz.app.domain.model.NoteDisplayMode
 import com.chordquiz.app.ui.theme.BarreColor
 import com.chordquiz.app.ui.theme.FingerDot
 import com.chordquiz.app.ui.theme.IncorrectRed
@@ -54,6 +56,9 @@ fun InteractiveChordDiagram(
     incorrectFrettedStrings: Set<Int> = emptySet(),
     incorrectMutedStrings: Set<Int> = emptySet(),
     missedMuteStrings: Set<Int> = emptySet(),
+    openStringNotes: List<Note> = emptyList(),
+    openStringOctaves: List<Int> = emptyList(),
+    noteDisplayMode: NoteDisplayMode = NoteDisplayMode.NONE,
     onFingeringChanged: (Fingering) -> Unit,
     onNoteSelected: ((stringIndex: Int, fret: Int) -> Unit)? = null,
     modifier: Modifier = Modifier
@@ -362,6 +367,69 @@ fun InteractiveChordDiagram(
             val y = topPad + (pos.fret - effectiveBaseFret + 0.5f) * fretSpacing
             val dotColor = if (pos.stringIndex in incorrectFrettedStrings) IncorrectRed else FingerDot
             drawCircle(dotColor, fretSpacing * 0.35f, Offset(x, y))
+        }
+
+        // Note labels
+        if (noteDisplayMode.showNotes() && openStringNotes.isNotEmpty() && openStringOctaves.isNotEmpty()) {
+            val noteFontSize = (fretSpacing * 0.22f / density).sp
+            val noteStyleOnDark = TextStyle(color = Color.White, fontSize = noteFontSize)
+            val noteStyleOnLight = TextStyle(color = Color.Black, fontSize = noteFontSize)
+
+            // Labels on finger dots
+            positions.filter { it.fret > 0 && it.fret in visibleRange }.forEach { pos ->
+                val openNote = openStringNotes.getOrNull(pos.stringIndex) ?: return@forEach
+                val openOctave = openStringOctaves.getOrNull(pos.stringIndex) ?: return@forEach
+                val note = openNote.plus(pos.fret)
+                val octave = openOctave + (openNote.semitone + pos.fret) / 12
+                val label = note.displayNameFor(noteDisplayMode, octave.takeIf { noteDisplayMode.showOctave() })
+                val x = effectiveLeftPad + pos.stringIndex * stringSpacing
+                val y = topPad + (pos.fret - effectiveBaseFret + 0.5f) * fretSpacing
+                val measured = textMeasurer.measure(label, style = noteStyleOnDark)
+                drawText(
+                    textMeasurer = textMeasurer,
+                    text = label,
+                    topLeft = Offset(x - measured.size.width / 2f, y - measured.size.height / 2f),
+                    style = noteStyleOnDark
+                )
+            }
+
+            // Labels on above-nut markers (open and muted)
+            positions.forEach { pos ->
+                if (pos.fret != -1 && pos.fret != 0) return@forEach
+                val openNote = openStringNotes.getOrNull(pos.stringIndex) ?: return@forEach
+                val openOctave = openStringOctaves.getOrNull(pos.stringIndex) ?: return@forEach
+                val note = openNote
+                val octave = openOctave + openNote.semitone / 12
+                val label = note.displayNameFor(noteDisplayMode, octave.takeIf { noteDisplayMode.showOctave() })
+                val x = effectiveLeftPad + pos.stringIndex * stringSpacing
+                val measured = textMeasurer.measure(label, style = noteStyleOnLight)
+                drawText(
+                    textMeasurer = textMeasurer,
+                    text = label,
+                    topLeft = Offset(x - measured.size.width / 2f, symbolY - measured.size.height / 2f),
+                    style = noteStyleOnLight
+                )
+            }
+
+            // Labels on barre segments
+            barre?.takeIf { it.fret in visibleRange }?.let { b ->
+                val y = topPad + (b.fret - effectiveBaseFret + 0.5f) * fretSpacing
+                for (s in b.fromString..b.toString) {
+                    val openNote = openStringNotes.getOrNull(s) ?: continue
+                    val openOctave = openStringOctaves.getOrNull(s) ?: continue
+                    val note = openNote.plus(b.fret)
+                    val octave = openOctave + (openNote.semitone + b.fret) / 12
+                    val label = note.displayNameFor(noteDisplayMode, octave.takeIf { noteDisplayMode.showOctave() })
+                    val x = effectiveLeftPad + s * stringSpacing
+                    val measured = textMeasurer.measure(label, style = noteStyleOnDark)
+                    drawText(
+                        textMeasurer = textMeasurer,
+                        text = label,
+                        topLeft = Offset(x - measured.size.width / 2f, y - measured.size.height / 2f),
+                        style = noteStyleOnDark
+                    )
+                }
+            }
         }
 
         // Faint tap-target hint grid

--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -64,6 +64,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chordquiz.app.data.model.ChordType
 import com.chordquiz.app.ui.components.chord.ChordDiagram
+import com.chordquiz.app.ui.screen.settings.SettingsViewModel
 import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -72,9 +73,11 @@ fun ChordLibraryScreen(
     instrumentId: String,
     onNavigateBack: () -> Unit,
     onStartPractice: (String, List<String>) -> Unit,
-    viewModel: ChordLibraryViewModel = hiltViewModel()
+    viewModel: ChordLibraryViewModel = hiltViewModel(),
+    settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val settings by settingsViewModel.uiState.collectAsStateWithLifecycle()
     var showSaveDialog by remember { mutableStateOf(false) }
     var dialogInitialName by remember { mutableStateOf("") }
     var groupName by remember(showSaveDialog) { mutableStateOf(dialogInitialName) }
@@ -221,7 +224,7 @@ fun ChordLibraryScreen(
                                     modifier = Modifier.size(width = 80.dp, height = 96.dp)
                                 )
                                 Text(
-                                    text = chord.chordName,
+                                    text = chord.displayName(settings.noteDisplayMode),
                                     style = MaterialTheme.typography.labelMedium,
                                     modifier = Modifier.padding(bottom = 4.dp)
                                 )

--- a/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewScreen.kt
@@ -48,7 +48,9 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chordquiz.app.data.model.ChordDefinition
+import com.chordquiz.app.domain.model.NoteDisplayMode
 import com.chordquiz.app.ui.components.chord.ChordDiagram
+import com.chordquiz.app.ui.screen.settings.SettingsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,9 +59,11 @@ fun ChordPreviewScreen(
     selectedChordIds: List<String>,
     onBack: () -> Unit,
     onBegin: () -> Unit,
-    viewModel: ChordPreviewViewModel = hiltViewModel()
+    viewModel: ChordPreviewViewModel = hiltViewModel(),
+    settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val settings by settingsViewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(instrumentId, selectedChordIds) {
         viewModel.initialize(instrumentId, selectedChordIds)
@@ -116,6 +120,7 @@ fun ChordPreviewScreen(
                     itemsIndexed(state.chords) { index, chord ->
                         ChordPreviewCard(
                             chord = chord,
+                            displayName = chord.displayName(settings.noteDisplayMode),
                             onClick = { selectedChordIndex = index }
                         )
                     }
@@ -125,6 +130,7 @@ fun ChordPreviewScreen(
                     ChordDetailModal(
                         chords = state.chords,
                         initialIndex = index,
+                        noteDisplayMode = settings.noteDisplayMode,
                         onDismiss = { selectedChordIndex = null }
                     )
                 }
@@ -136,6 +142,7 @@ fun ChordPreviewScreen(
 @Composable
 private fun ChordPreviewCard(
     chord: ChordDefinition,
+    displayName: String,
     onClick: () -> Unit
 ) {
     Box(
@@ -155,7 +162,7 @@ private fun ChordPreviewCard(
                 modifier = Modifier.size(width = 80.dp, height = 96.dp)
             )
             Text(
-                text = chord.chordName,
+                text = displayName,
                 style = MaterialTheme.typography.labelMedium,
                 modifier = Modifier.padding(bottom = 4.dp)
             )
@@ -168,6 +175,7 @@ private fun ChordPreviewCard(
 private fun ChordDetailModal(
     chords: List<ChordDefinition>,
     initialIndex: Int,
+    noteDisplayMode: NoteDisplayMode,
     onDismiss: () -> Unit
 ) {
     var currentIndex by remember(initialIndex) { mutableIntStateOf(initialIndex) }
@@ -181,7 +189,7 @@ private fun ChordDetailModal(
             Scaffold(
                 topBar = {
                     TopAppBar(
-                        title = { Text(chord.chordName, style = MaterialTheme.typography.titleLarge) },
+                        title = { Text(chord.displayName(noteDisplayMode), style = MaterialTheme.typography.titleLarge) },
                         navigationIcon = {
                             IconButton(onClick = onDismiss) {
                                 Icon(Icons.Default.Close, contentDescription = "Close")
@@ -225,7 +233,7 @@ private fun ChordDetailModal(
                     verticalArrangement = Arrangement.Center
                 ) {
                     Text(
-                        text = chord.chordName,
+                        text = chord.displayName(noteDisplayMode),
                         style = MaterialTheme.typography.displayMedium
                     )
 

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
@@ -167,7 +167,7 @@ fun DrawQuizScreen(
 
                     Text("Draw this chord:", style = MaterialTheme.typography.bodyLarge)
                     Text(
-                        text = question.chordDefinition.chordName,
+                        text = question.chordDefinition.displayName(settings.noteDisplayMode),
                         style = MaterialTheme.typography.displayLarge.copy(
                             fontWeight = FontWeight.Bold,
                             fontSize = 64.sp
@@ -217,6 +217,9 @@ fun DrawQuizScreen(
                                 incorrectFrettedStrings = state.incorrectFrettedStrings,
                                 incorrectMutedStrings = state.incorrectMutedStrings,
                                 missedMuteStrings = state.missedMuteStrings,
+                                openStringNotes = session.instrument.openStringNotes,
+                                openStringOctaves = session.instrument.openStringOctaves,
+                                noteDisplayMode = settings.noteDisplayMode,
                                 onFingeringChanged = { viewModel.onFingeringChanged(it) },
                                 onNoteSelected = { strIdx, fret -> viewModel.onNoteSelected(strIdx, fret) },
                                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizplay/PlayQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizplay/PlayQuizScreen.kt
@@ -53,6 +53,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chordquiz.app.ui.components.AudioWaveform
 import com.chordquiz.app.ui.components.chord.ChordDiagram
+import com.chordquiz.app.ui.screen.settings.SettingsViewModel
 import com.chordquiz.app.ui.theme.CorrectGreen
 import com.chordquiz.app.ui.theme.IncorrectRed
 
@@ -65,9 +66,11 @@ fun PlayQuizScreen(
     repeatMissed: Boolean,
     onNavigateBack: () -> Unit,
     onQuizComplete: (String) -> Unit,
-    viewModel: PlayQuizViewModel = hiltViewModel()
+    viewModel: PlayQuizViewModel = hiltViewModel(),
+    settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val settings by settingsViewModel.uiState.collectAsStateWithLifecycle()
     var permissionGranted by remember { mutableStateOf(false) }
 
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -143,7 +146,7 @@ fun PlayQuizScreen(
                     Text("Play this chord:", style = MaterialTheme.typography.bodyLarge)
 
                     Text(
-                        text = question.chordDefinition.chordName,
+                        text = question.chordDefinition.displayName(settings.noteDisplayMode),
                         style = MaterialTheme.typography.displayLarge.copy(
                             fontWeight = FontWeight.Bold,
                             fontSize = 64.sp
@@ -186,7 +189,7 @@ fun PlayQuizScreen(
                             if (state.detectedNotes.isNotEmpty()) {
                                 Spacer(Modifier.height(8.dp))
                                 Text(
-                                    "Detected: ${state.detectedNotes.joinToString(" ") { it.displayName }}",
+                                    "Detected: ${state.detectedNotes.joinToString(" ") { it.displayNameFor(settings.noteDisplayMode) }}",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )

--- a/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsScreen.kt
@@ -12,11 +12,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -26,6 +31,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -34,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chordquiz.app.domain.model.Difficulty
+import com.chordquiz.app.domain.model.NoteDisplayMode
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -91,6 +100,10 @@ fun SettingsScreen(
             HapticFeedbackToggle(
                 enabled = settings.hapticFeedbackEnabled,
                 onToggle = { viewModel.toggleHapticFeedback(it) }
+            )
+            NoteDisplayModeDropdown(
+                selected = settings.noteDisplayMode,
+                onSelect = { viewModel.setNoteDisplayMode(it) }
             )
         }
     }
@@ -206,8 +219,70 @@ fun DifficultySelector(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NoteDisplayModeDropdown(
+    selected: NoteDisplayMode,
+    onSelect: (NoteDisplayMode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val options = linkedMapOf(
+        NoteDisplayMode.NONE to "◌  None",
+        NoteDisplayMode.SHARP to "C#  Sharps",
+        NoteDisplayMode.FLAT to "Bb  Flats",
+        NoteDisplayMode.SHARP_OCTAVE to "C#4  Sharps + Octave",
+        NoteDisplayMode.FLAT_OCTAVE to "Bb4  Flats + Octave"
+    )
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text("Notes on fretboard", style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = "Show note names on the interactive diagram",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            OutlinedTextField(
+                value = options[selected] ?: "",
+                onValueChange = {},
+                readOnly = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                options.forEach { (mode, label) ->
+                    DropdownMenuItem(
+                        text = { Text(label) },
+                        onClick = {
+                            onSelect(mode)
+                            expanded = false
+                        },
+                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                    )
+                }
+            }
+        }
+    }
+}
+
 data class Settings(
     val hapticFeedbackEnabled: Boolean = true,
     val autoContinueDelaySeconds: Int = 2,
-    val difficulty: Difficulty = Difficulty.DEFAULT
+    val difficulty: Difficulty = Difficulty.DEFAULT,
+    val noteDisplayMode: NoteDisplayMode = NoteDisplayMode.NONE
 )

--- a/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chordquiz.app.data.preferences.UserPreferencesRepository
 import com.chordquiz.app.domain.model.Difficulty
+import com.chordquiz.app.domain.model.NoteDisplayMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -39,6 +40,11 @@ class SettingsViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(difficulty = difficulty)
             }
         }
+        viewModelScope.launch {
+            userPreferencesRepository.noteDisplayMode.collect { mode ->
+                _uiState.value = _uiState.value.copy(noteDisplayMode = mode)
+            }
+        }
     }
 
     fun toggleHapticFeedback(enabled: Boolean) {
@@ -56,6 +62,12 @@ class SettingsViewModel @Inject constructor(
     fun setDifficulty(difficulty: Difficulty) {
         viewModelScope.launch {
             userPreferencesRepository.setDifficulty(difficulty)
+        }
+    }
+
+    fun setNoteDisplayMode(mode: NoteDisplayMode) {
+        viewModelScope.launch {
+            userPreferencesRepository.setNoteDisplayMode(mode)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `NoteDisplayMode` enum (NONE, SHARP, FLAT, SHARP_OCTAVE, FLAT_OCTAVE) with helpers
- Adds a **Notes on fretboard** dropdown to Draw Mode Settings (default: ◌ None)
- Renders note labels inside finger dots, open-string circles, muted-string markers, and barre segments on the interactive diagram in Draw mode
- Sharp/flat preference applies app-wide: chord names in the library, preview screen, quiz prompts, and detected notes display all respect the setting
- Note labels are never shown in Play mode (fretboard suppressed as required)

## Test plan
- [ ] Build passes in CI
- [ ] Open Settings → Draw Mode → "Notes on fretboard" dropdown shows all 5 options
- [ ] Selecting C# shows sharp note names inside dots/circles/X/barre in Draw mode
- [ ] Selecting Bb shows flat equivalents (C# → Db, etc.)
- [ ] Selecting C#4 / Bb4 appends octave numbers
- [ ] Selecting ◌ (None) hides all note labels (default behavior unchanged)
- [ ] Chord names in library and preview flip between sharps/flats when setting changes
- [ ] Play mode quiz prompt reflects sharp/flat preference; no note labels on fretboard diagram

🤖 Generated with [Claude Code](https://claude.ai/claude-code)