### PR TITLE
fix: overhaul Note Quiz draw mode interactions (closes #79)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/domain/EvaluateNoteDrawAnswerUseCase.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/EvaluateNoteDrawAnswerUseCase.kt
@@ -10,6 +10,7 @@ import javax.inject.Inject
 
 data class NoteDrawEvalResult(
     val isCorrect: Boolean,
+    val isComplete: Boolean = false,
     val missedPositions: List<StringPosition> = emptyList()
 )
 
@@ -59,7 +60,8 @@ class EvaluateNoteDrawAnswerUseCase @Inject constructor() {
                     .map { (_, _, strIdx) -> strIdx }
                     .toSet()
                 val missedPositions = allPositions.filter { it.stringIndex !in markedStrings }
-                NoteDrawEvalResult(isCorrect = missedPositions.isEmpty(), missedPositions = missedPositions)
+                val isCorrect = missedPositions.isEmpty()
+                NoteDrawEvalResult(isCorrect = isCorrect, isComplete = isCorrect, missedPositions = missedPositions)
             }
 
             NoteMode.FIND_ALL_NOTES_CORRECT_OCTAVE -> {
@@ -70,9 +72,20 @@ class EvaluateNoteDrawAnswerUseCase @Inject constructor() {
                     .map { (_, _, strIdx) -> strIdx }
                     .toSet()
                 val missedPositions = allPositions.filter { it.stringIndex !in markedPairs }
-                NoteDrawEvalResult(isCorrect = missedPositions.isEmpty(), missedPositions = missedPositions)
+                val isCorrect = missedPositions.isEmpty()
+                NoteDrawEvalResult(isCorrect = isCorrect, isComplete = isCorrect, missedPositions = missedPositions)
             }
         }
+    }
+
+    fun computeAllPositionsForQuestion(
+        instrument: Instrument,
+        question: QuizQuestion.NoteQuestion
+    ): List<StringPosition> = when (question.noteMode) {
+        NoteMode.FIND_ALL_NOTES_CORRECT_OCTAVE, NoteMode.FIND_NOTE_CORRECT_OCTAVE ->
+            computeAllPositions(instrument, question.note.semitone, question.octave)
+        else ->
+            computeAllPositions(instrument, question.note.semitone, null)
     }
 
     private fun computeAllPositions(

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -40,11 +40,14 @@ import com.chordquiz.app.ui.theme.StringColor
  * Tap above the nut to cycle a string: open → muted → open.
  * Drag right-to-left along a fret to draw a barre across multiple strings.
  *
+ * @param noteQuizMode             when true: disables mute/barre, treats fret=-1 as empty and
+ *                                  fret=0 as an open-string dot; above-nut area toggles fret 0
+ * @param hintPositions            (stringIndex, fret) pairs rendered as yellow hint dots
  * @param incorrectFrettedStrings  strings where the user placed a wrong-note finger (shown red)
  * @param incorrectMutedStrings    strings the user muted but shouldn't have (X shown red)
  * @param missedMuteStrings        strings that should be muted but the user left open/fretted
  *                                  (open-circle shown red as a hint)
- * @param onNoteSelected           called when a finger is placed (fret > 0) or a string opened (fret == 0)
+ * @param onNoteSelected           called when a finger is placed (fret >= 0)
  */
 @Composable
 fun InteractiveChordDiagram(
@@ -53,6 +56,8 @@ fun InteractiveChordDiagram(
     baseFret: Int = 1,
     totalFrets: Int = 21,
     initialFingering: Fingering? = null,
+    noteQuizMode: Boolean = false,
+    hintPositions: Set<Pair<Int, Int>> = emptySet(),
     incorrectFrettedStrings: Set<Int> = emptySet(),
     incorrectMutedStrings: Set<Int> = emptySet(),
     missedMuteStrings: Set<Int> = emptySet(),
@@ -119,15 +124,27 @@ fun InteractiveChordDiagram(
                     // and can be called from both the "pure tap" and "short drag" paths.
                     fun performTap() {
                         if (!touchDownInFretGrid) {
-                            // Above nut: toggle open ↔ muted
-                            val cur = positions.firstOrNull { it.stringIndex == touchDownString }?.fret ?: 0
-                            val newFret = if (cur == -1) 0 else -1
-                            positions = positions.toMutableList().also { list ->
-                                val idx = list.indexOfFirst { it.stringIndex == touchDownString }
-                                if (idx >= 0) list[idx] = StringPosition(touchDownString, newFret)
+                            if (noteQuizMode) {
+                                // Note quiz: above-nut area toggles open-string dot (fret=0) on/off
+                                val cur = positions.firstOrNull { it.stringIndex == touchDownString }?.fret ?: -1
+                                val newFret = if (cur == 0) -1 else 0
+                                positions = positions.toMutableList().also { list ->
+                                    val idx = list.indexOfFirst { it.stringIndex == touchDownString }
+                                    if (idx >= 0) list[idx] = StringPosition(touchDownString, newFret)
+                                }
+                                onFingeringChanged(Fingering(positions.toList(), null, effectiveBaseFret))
+                                if (newFret == 0) onNoteSelected?.invoke(touchDownString, 0)
+                            } else {
+                                // Chord mode: toggle open ↔ muted
+                                val cur = positions.firstOrNull { it.stringIndex == touchDownString }?.fret ?: 0
+                                val newFret = if (cur == -1) 0 else -1
+                                positions = positions.toMutableList().also { list ->
+                                    val idx = list.indexOfFirst { it.stringIndex == touchDownString }
+                                    if (idx >= 0) list[idx] = StringPosition(touchDownString, newFret)
+                                }
+                                onFingeringChanged(Fingering(positions.toList(), barre, effectiveBaseFret))
+                                if (newFret == 0) onNoteSelected?.invoke(touchDownString, 0)
                             }
-                            onFingeringChanged(Fingering(positions.toList(), barre, effectiveBaseFret))
-                            if (newFret == 0) onNoteSelected?.invoke(touchDownString, 0)
                             return
                         }
 
@@ -168,13 +185,14 @@ fun InteractiveChordDiagram(
 
                         // Regular fret tap: toggle dot on/off
                         val curPos = positions.firstOrNull { it.stringIndex == touchDownString }
-                        val newFret = if (curPos?.fret == touchDownFret) 0 else touchDownFret
+                        val emptyFret = if (noteQuizMode) -1 else 0
+                        val newFret = if (curPos?.fret == touchDownFret) emptyFret else touchDownFret
                         positions = positions.toMutableList().also { list ->
                             val idx = list.indexOfFirst { it.stringIndex == touchDownString }
                             if (idx >= 0) list[idx] = StringPosition(touchDownString, newFret)
                             else list.add(StringPosition(touchDownString, newFret))
                         }
-                        onFingeringChanged(Fingering(positions.toList(), barre, effectiveBaseFret))
+                        onFingeringChanged(Fingering(positions.toList(), if (noteQuizMode) null else barre, effectiveBaseFret))
                         if (newFret > 0) onNoteSelected?.invoke(touchDownString, newFret)
                     }
 
@@ -194,13 +212,13 @@ fun InteractiveChordDiagram(
                             kotlin.math.abs(dx) > kotlin.math.abs(dy)
                         ) {
                             gestureClassified = true
-                            if (dx < 0 && touchDownInFretGrid) {
-                                // Right-to-left drag in fret grid → barre mode
+                            if (dx < 0 && touchDownInFretGrid && !noteQuizMode) {
+                                // Right-to-left drag in fret grid → barre mode (chord mode only)
                                 isBarreDrag = true
                                 barre = null
                                 positions = basePositions.toMutableList()
                             } else {
-                                // Left-to-right drag (or above-nut drag) → let bubble to parent
+                                // Left-to-right drag, above-nut drag, or note quiz → bubble to parent
                                 break
                             }
                         }
@@ -333,24 +351,49 @@ fun InteractiveChordDiagram(
             }
         }
 
-        // Above-nut markers (open circle or muted X)
+        // Above-nut markers (open circle or muted X, or filled dot in note quiz mode)
         val symbolY = topPad - fretSpacing * 0.45f
         val symbolRadius = size.width * 0.035f
         positions.forEach { pos ->
             val x = effectiveLeftPad + pos.stringIndex * stringSpacing
-            when (pos.fret) {
-                -1 -> {
-                    // Muted X — red if incorrectly muted, gray otherwise
-                    val xColor = if (pos.stringIndex in incorrectMutedStrings) IncorrectRed else MutedGray
-                    drawLine(xColor, Offset(x - symbolRadius, symbolY - symbolRadius),
-                        Offset(x + symbolRadius, symbolY + symbolRadius), 2f)
-                    drawLine(xColor, Offset(x + symbolRadius, symbolY - symbolRadius),
-                        Offset(x - symbolRadius, symbolY + symbolRadius), 2f)
+            if (noteQuizMode) {
+                when (pos.fret) {
+                    0 -> {
+                        // Note quiz open-string dot — filled dot at nut row
+                        drawCircle(FingerDot, fretSpacing * 0.35f, Offset(x, symbolY))
+                    }
+                    // fret=-1 (empty) → draw nothing
                 }
-                0 -> {
-                    // Open circle — red if this string should have been muted or fretted, black otherwise
-                    val oColor = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings) IncorrectRed else Color.Black
-                    drawCircle(oColor, symbolRadius, Offset(x, symbolY), style = Stroke(2f))
+            } else {
+                when (pos.fret) {
+                    -1 -> {
+                        // Muted X — red if incorrectly muted, gray otherwise
+                        val xColor = if (pos.stringIndex in incorrectMutedStrings) IncorrectRed else MutedGray
+                        drawLine(xColor, Offset(x - symbolRadius, symbolY - symbolRadius),
+                            Offset(x + symbolRadius, symbolY + symbolRadius), 2f)
+                        drawLine(xColor, Offset(x + symbolRadius, symbolY - symbolRadius),
+                            Offset(x - symbolRadius, symbolY + symbolRadius), 2f)
+                    }
+                    0 -> {
+                        // Open circle — red if this string should have been muted or fretted, black otherwise
+                        val oColor = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings) IncorrectRed else Color.Black
+                        drawCircle(oColor, symbolRadius, Offset(x, symbolY), style = Stroke(2f))
+                    }
+                }
+            }
+        }
+
+        // Hint dots (yellow) — shown in note quiz mode for valid positions after wrong tap
+        if (hintPositions.isNotEmpty()) {
+            val hintColor = Color(0xFFFFCC00)
+            hintPositions.forEach { (stringIdx, fret) ->
+                val x = effectiveLeftPad + stringIdx * stringSpacing
+                if (fret == 0) {
+                    // Open-string hint dot at nut row
+                    drawCircle(hintColor, fretSpacing * 0.35f, Offset(x, symbolY))
+                } else if (fret in (effectiveBaseFret)..(effectiveBaseFret + displayedFrets - 1)) {
+                    val y = topPad + (fret - effectiveBaseFret + 0.5f) * fretSpacing
+                    drawCircle(hintColor, fretSpacing * 0.35f, Offset(x, y))
                 }
             }
         }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/notedrawquiz/NoteDrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/notedrawquiz/NoteDrawQuizScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -84,24 +83,39 @@ fun NoteDrawQuizScreen(
             val stringCount = session.instrument.stringCount
             val autoContinueDelayMs = settings.autoContinueDelaySeconds * 1000
 
-            // Auto-advance after delay when feedback is shown
+            // Auto-advance after delay when correct feedback is shown
+            // (FIND_ALL wrong feedback clears itself without advancing)
             LaunchedEffect(state.feedback) {
-                if (state.feedback != null) {
+                if (state.feedback == NoteDrawFeedback.CORRECT) {
+                    delay(autoContinueDelayMs.toLong())
+                    viewModel.nextQuestion()
+                } else if (state.feedback == NoteDrawFeedback.INCORRECT &&
+                    (noteQuestion.noteMode == NoteMode.FIND_NOTE ||
+                     noteQuestion.noteMode == NoteMode.FIND_NOTE_CORRECT_OCTAVE)
+                ) {
+                    // Single-note wrong: auto-advance after same delay
                     delay(autoContinueDelayMs.toLong())
                     viewModel.nextQuestion()
                 }
             }
 
             val countdownProgress by animateFloatAsState(
-                targetValue = if (state.feedback != null) 0f else 1f,
-                animationSpec = if (state.feedback != null)
+                targetValue = if (state.feedback != null &&
+                    (state.feedback == NoteDrawFeedback.CORRECT ||
+                     noteQuestion.noteMode == NoteMode.FIND_NOTE ||
+                     noteQuestion.noteMode == NoteMode.FIND_NOTE_CORRECT_OCTAVE)
+                ) 0f else 1f,
+                animationSpec = if (state.feedback != null &&
+                    (state.feedback == NoteDrawFeedback.CORRECT ||
+                     noteQuestion.noteMode == NoteMode.FIND_NOTE ||
+                     noteQuestion.noteMode == NoteMode.FIND_NOTE_CORRECT_OCTAVE)
+                )
                     tween(durationMillis = autoContinueDelayMs, easing = LinearEasing)
                 else
                     snap(),
                 label = "countdown"
             )
 
-            // Build the note prompt text
             val promptText = when (noteQuestion.noteMode) {
                 NoteMode.FIND_NOTE, NoteMode.FIND_ALL_NOTES -> noteQuestion.displayName
                 NoteMode.FIND_NOTE_CORRECT_OCTAVE, NoteMode.FIND_ALL_NOTES_CORRECT_OCTAVE ->
@@ -109,11 +123,17 @@ fun NoteDrawQuizScreen(
             }
 
             val instructionText = when (noteQuestion.noteMode) {
-                NoteMode.FIND_NOTE -> "Find any position for this note"
-                NoteMode.FIND_NOTE_CORRECT_OCTAVE -> "Find this exact note and octave"
-                NoteMode.FIND_ALL_NOTES -> "Find all positions for this note"
-                NoteMode.FIND_ALL_NOTES_CORRECT_OCTAVE -> "Find all positions for this exact octave"
+                NoteMode.FIND_NOTE -> "Tap any position for this note"
+                NoteMode.FIND_NOTE_CORRECT_OCTAVE -> "Tap this exact note and octave"
+                NoteMode.FIND_ALL_NOTES -> "Tap all positions for this note"
+                NoteMode.FIND_ALL_NOTES_CORRECT_OCTAVE -> "Tap all positions for this exact octave"
             }
+
+            // Show countdown only when auto-advancing (correct or single-note wrong)
+            val showCountdown = state.feedback != null &&
+                (state.feedback == NoteDrawFeedback.CORRECT ||
+                 noteQuestion.noteMode == NoteMode.FIND_NOTE ||
+                 noteQuestion.noteMode == NoteMode.FIND_NOTE_CORRECT_OCTAVE)
 
             Scaffold(
                 topBar = {
@@ -154,7 +174,7 @@ fun NoteDrawQuizScreen(
                         color = MaterialTheme.colorScheme.primary
                     )
 
-                    key(state.displayedQuestionIndex) {
+                    key(state.displayedQuestionIndex, state.wrongTapResetKey) {
                         Box(
                             modifier = Modifier
                                 .width(220.dp)
@@ -164,27 +184,31 @@ fun NoteDrawQuizScreen(
                                 stringCount = stringCount,
                                 totalFrets = session.instrument.totalFrets,
                                 initialFingering = state.currentFingering,
-                                incorrectFrettedStrings = state.missedPositions,
+                                noteQuizMode = true,
+                                hintPositions = state.hintPositions,
+                                incorrectFrettedStrings = emptySet(),
                                 incorrectMutedStrings = emptySet(),
                                 missedMuteStrings = emptySet(),
                                 openStringNotes = session.instrument.openStringNotes,
                                 openStringOctaves = session.instrument.openStringOctaves,
                                 noteDisplayMode = settings.noteDisplayMode,
                                 onFingeringChanged = { viewModel.onFingeringChanged(it) },
-                                onNoteSelected = { _, _ -> },
+                                onNoteSelected = { stringIndex, fret ->
+                                    viewModel.onNoteSelected(stringIndex, fret)
+                                },
                                 modifier = Modifier.fillMaxSize()
                             )
                         }
                     }
 
                     Text(
-                        "Tap strings/frets to place fingers",
+                        "Tap strings/frets to mark notes",
                         style = MaterialTheme.typography.bodySmall,
                         textAlign = TextAlign.Center,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
-                    if (state.feedback != null) {
+                    if (showCountdown) {
                         LinearProgressIndicator(
                             progress = { countdownProgress },
                             modifier = Modifier.fillMaxWidth()
@@ -218,15 +242,6 @@ fun NoteDrawQuizScreen(
                     }
 
                     Spacer(Modifier.weight(1f))
-
-                    if (state.feedback == null) {
-                        Button(
-                            onClick = { viewModel.submitAnswer() },
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text("Submit")
-                        }
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/notedrawquiz/NoteDrawQuizViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/notedrawquiz/NoteDrawQuizViewModel.kt
@@ -2,6 +2,7 @@ package com.chordquiz.app.ui.screen.notedrawquiz
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chordquiz.app.audio.NotePlayer
 import com.chordquiz.app.data.model.Fingering
 import com.chordquiz.app.data.model.Instrument
 import com.chordquiz.app.data.model.NoteMode
@@ -15,6 +16,7 @@ import com.chordquiz.app.domain.EvaluateNoteDrawAnswerUseCase
 import com.chordquiz.app.haptic.HapticManager
 import com.chordquiz.app.ui.shared.SessionStore
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -27,7 +29,12 @@ sealed class NoteDrawQuizUiState {
         val session: QuizSession,
         val currentFingering: Fingering,
         val feedback: NoteDrawFeedback? = null,
-        val missedPositions: Set<Int> = emptySet(),
+        /** Yellow hint dots shown after a wrong tap in single-note modes: (stringIndex, fret) */
+        val hintPositions: Set<Pair<Int, Int>> = emptySet(),
+        /** Correctly placed positions accumulated during FIND_ALL modes */
+        val correctlyPlacedPositions: Set<Pair<Int, Int>> = emptySet(),
+        /** Increments on wrong tap in FIND_ALL modes to reset the diagram to correct-only state */
+        val wrongTapResetKey: Int = 0,
         val displayedQuestion: QuizQuestion? = null,
         val displayedQuestionIndex: Int = 0
     ) : NoteDrawQuizUiState()
@@ -71,38 +78,118 @@ class NoteDrawQuizViewModel @Inject constructor(
 
     fun onFingeringChanged(fingering: Fingering) {
         val state = _uiState.value as? NoteDrawQuizUiState.Active ?: return
-        if (state.feedback != null) return
-        _uiState.value = state.copy(
-            currentFingering = fingering,
-            feedback = null,
-            missedPositions = emptySet()
-        )
-    }
-
-    fun submitAnswer() {
-        val state = _uiState.value as? NoteDrawQuizUiState.Active ?: return
+        if (state.feedback != null) return  // locked during countdown
         val inst = instrument ?: return
         val question = state.displayedQuestion ?: state.session.currentQuestion ?: return
         val noteQuestion = question as? QuizQuestion.NoteQuestion ?: return
 
-        val result = evaluateNoteDrawAnswer(inst, state.currentFingering, noteQuestion)
+        // Find a newly placed position (fret changed from -1 to anything >= 0)
+        val oldByString = state.currentFingering.positions.associateBy { it.stringIndex }
+        val newlyPlaced = fingering.positions.firstOrNull { newPos ->
+            val oldFret = oldByString[newPos.stringIndex]?.fret ?: -1
+            newPos.fret >= 0 && newPos.fret != oldFret
+        }
 
-        val answer = QuizAnswer(
-            question = noteQuestion,
-            isCorrect = result.isCorrect,
-            userFingering = state.currentFingering
-        )
-        val newSession = state.session.copy(answers = state.session.answers + answer)
-        _uiState.value = state.copy(
-            session = newSession,
-            feedback = if (result.isCorrect) NoteDrawFeedback.CORRECT else NoteDrawFeedback.INCORRECT,
-            missedPositions = result.missedPositions.map { it.stringIndex }.toSet()
-        )
+        if (newlyPlaced == null) {
+            // Removal or no meaningful change — update silently
+            _uiState.value = state.copy(currentFingering = fingering)
+            return
+        }
 
-        if (!result.isCorrect) {
-            viewModelScope.launch {
-                hapticManager.vibrateWrongAnswer()
+        when (noteQuestion.noteMode) {
+            NoteMode.FIND_NOTE, NoteMode.FIND_NOTE_CORRECT_OCTAVE -> {
+                // Single-position mode: each placement is an immediate submission
+                val isCorrect = isPositionCorrect(inst, newlyPlaced, noteQuestion)
+                val answer = QuizAnswer(
+                    question = noteQuestion,
+                    isCorrect = isCorrect,
+                    userFingering = fingering
+                )
+                val newSession = state.session.copy(answers = state.session.answers + answer)
+                val hints = if (!isCorrect) {
+                    evaluateNoteDrawAnswer
+                        .computeAllPositionsForQuestion(inst, noteQuestion)
+                        .map { Pair(it.stringIndex, it.fret) }
+                        .toSet()
+                } else emptySet()
+
+                _uiState.value = state.copy(
+                    session = newSession,
+                    currentFingering = fingering,
+                    feedback = if (isCorrect) NoteDrawFeedback.CORRECT else NoteDrawFeedback.INCORRECT,
+                    hintPositions = hints
+                )
+
+                if (!isCorrect) {
+                    viewModelScope.launch { hapticManager.vibrateWrongAnswer() }
+                }
             }
+
+            NoteMode.FIND_ALL_NOTES, NoteMode.FIND_ALL_NOTES_CORRECT_OCTAVE -> {
+                // All-positions mode: validate each tap individually
+                val isCorrect = isPositionCorrect(inst, newlyPlaced, noteQuestion)
+
+                if (!isCorrect) {
+                    // Wrong note tapped: show feedback, reset diagram to correct-only state
+                    val correctFingering = buildPartialFingering(inst.stringCount, state.correctlyPlacedPositions)
+                    _uiState.value = state.copy(
+                        currentFingering = correctFingering,
+                        feedback = NoteDrawFeedback.INCORRECT,
+                        wrongTapResetKey = state.wrongTapResetKey + 1
+                    )
+                    viewModelScope.launch { hapticManager.vibrateWrongAnswer() }
+                    // Clear feedback after a short delay without advancing
+                    viewModelScope.launch {
+                        delay(1000L)
+                        val current = _uiState.value as? NoteDrawQuizUiState.Active ?: return@launch
+                        if (current.feedback == NoteDrawFeedback.INCORRECT) {
+                            _uiState.value = current.copy(feedback = null)
+                        }
+                    }
+                } else {
+                    // Correct placement — add to correctly placed set
+                    val newCorrect = state.correctlyPlacedPositions +
+                        Pair(newlyPlaced.stringIndex, newlyPlaced.fret)
+                    val allPositions = evaluateNoteDrawAnswer
+                        .computeAllPositionsForQuestion(inst, noteQuestion)
+                    val isComplete = allPositions.all { pos ->
+                        Pair(pos.stringIndex, pos.fret) in newCorrect
+                    }
+
+                    if (isComplete) {
+                        // All positions found — auto-submit as correct
+                        val answer = QuizAnswer(
+                            question = noteQuestion,
+                            isCorrect = true,
+                            userFingering = fingering
+                        )
+                        val newSession = state.session.copy(answers = state.session.answers + answer)
+                        _uiState.value = state.copy(
+                            session = newSession,
+                            currentFingering = fingering,
+                            feedback = NoteDrawFeedback.CORRECT,
+                            correctlyPlacedPositions = newCorrect
+                        )
+                    } else {
+                        // Not yet complete — update silently
+                        _uiState.value = state.copy(
+                            currentFingering = fingering,
+                            correctlyPlacedPositions = newCorrect
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun onNoteSelected(stringIndex: Int, fret: Int) {
+        val inst = instrument ?: return
+        if (fret < 0) return
+        val openNote = inst.openStringNotes.getOrNull(stringIndex) ?: return
+        val openOctave = inst.openStringOctaves.getOrNull(stringIndex) ?: return
+        val midi = openNote.semitone + 12 * (openOctave + 1) + fret
+        viewModelScope.launch {
+            NotePlayer.playNote(midi, inst.id)
         }
     }
 
@@ -117,14 +204,45 @@ class NoteDrawQuizViewModel @Inject constructor(
             _uiState.value = state.copy(
                 currentFingering = emptyFingering(inst.stringCount),
                 feedback = null,
-                missedPositions = emptySet(),
+                hintPositions = emptySet(),
+                correctlyPlacedPositions = emptySet(),
+                wrongTapResetKey = 0,
                 displayedQuestion = nextQuestion,
                 displayedQuestionIndex = state.displayedQuestionIndex + 1
             )
         }
     }
 
+    private fun isPositionCorrect(
+        instrument: Instrument,
+        pos: StringPosition,
+        question: QuizQuestion.NoteQuestion
+    ): Boolean {
+        val openNote = instrument.openStringNotes.getOrNull(pos.stringIndex) ?: return false
+        val openOctave = instrument.openStringOctaves.getOrNull(pos.stringIndex) ?: return false
+        val totalSemitones = openNote.semitone + pos.fret
+        val semitone = totalSemitones % 12
+        val octave = openOctave + totalSemitones / 12
+        return when (question.noteMode) {
+            NoteMode.FIND_NOTE, NoteMode.FIND_ALL_NOTES ->
+                semitone == question.note.semitone
+            NoteMode.FIND_NOTE_CORRECT_OCTAVE, NoteMode.FIND_ALL_NOTES_CORRECT_OCTAVE ->
+                semitone == question.note.semitone && octave == question.octave
+        }
+    }
+
+    private fun buildPartialFingering(
+        stringCount: Int,
+        correct: Set<Pair<Int, Int>>
+    ): Fingering {
+        val positions = (0 until stringCount).map { s ->
+            val correctFret = correct.firstOrNull { it.first == s }?.second
+            StringPosition(s, correctFret ?: -1)
+        }
+        return Fingering(positions = positions)
+    }
+
     private fun emptyFingering(stringCount: Int) = Fingering(
-        positions = (0 until stringCount).map { StringPosition(it, 0) }
+        positions = (0 until stringCount).map { StringPosition(it, -1) }
     )
 }


### PR DESCRIPTION
## Summary

- **Remove mute/barre in Note Quiz**: `fret=-1` is now the empty state, `fret=0` is a tappable open-string dot rendered at the nut row (scrolls with nut). Barre gesture is disabled via `noteQuizMode` param.
- **FIND_NOTE / FIND_NOTE_CORRECT_OCTAVE**: Each tap auto-submits. Correct tap → green banner + auto-advance (respects Settings delay). Wrong tap → "Not quite!" banner + yellow hint dots at all valid fretboard positions + auto-advance after same delay.
- **FIND_ALL_NOTES / FIND_ALL_NOTES_CORRECT_OCTAVE**: Correct placements accumulate silently. Wrong note tap → wrong feedback + haptic + diagram resets to correct-only state (wrong dot auto-removed). When all positions are found, auto-submits as correct.
- **Note audio on every tap**: `onNoteSelected` wired to `NotePlayer.playNote` for selection feedback.

## Changed files

- `InteractiveChordDiagram.kt` — add `noteQuizMode: Boolean` + `hintPositions: Set<Pair<Int,Int>>`; note-quiz gesture and rendering logic
- `EvaluateNoteDrawAnswerUseCase.kt` — add `isComplete` to result; expose `computeAllPositionsForQuestion()`
- `NoteDrawQuizViewModel.kt` — full rewrite of evaluation flow; no more `submitAnswer()`; new `onNoteSelected()`; `wrongTapResetKey` for FIND_ALL resets
- `NoteDrawQuizScreen.kt` — remove Submit button; pass `noteQuizMode=true` + `hintPositions`; key diagram on `wrongTapResetKey`; conditional auto-advance logic

## Test plan

- [ ] FIND_NOTE: tap correct fret → green banner → auto-advances
- [ ] FIND_NOTE: tap wrong fret → "Not quite!" + yellow dots appear at all valid positions → auto-advances
- [ ] FIND_NOTE_CORRECT_OCTAVE: same as above with octave constraint
- [ ] FIND_ALL_NOTES: correct taps accumulate with no banner; wrong tap shows "Not quite!", dot disappears, correctly placed dots remain
- [ ] FIND_ALL_NOTES: placing all correct positions auto-submits with green banner
- [ ] Open-string position: tap above nut places filled dot; retap removes it; audio plays on placement
- [ ] No mute X or open O symbols appear in note quiz
- [ ] No barre can be drawn (horizontal drag exits gesture instead)
- [ ] Note audio plays on every tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)