### PR TITLE
fix: add strum instruction to Draw Quiz screen (closes #69)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizdraw/DrawQuizScreen.kt
@@ -230,7 +230,7 @@ fun DrawQuizScreen(
                     }
 
                     Text(
-                        "Tap strings/frets to place fingers\nTap above nut to toggle open/muted\nDrag right-to-left along a fret to draw a barre",
+                        "Tap strings/frets to place fingers\nTap above nut to toggle open/muted\nDrag right-to-left along a fret to draw a barre\nStrum from left-to-right to submit answer",
                         style = MaterialTheme.typography.bodySmall,
                         textAlign = TextAlign.Center,
                         color = MaterialTheme.colorScheme.onSurfaceVariant


### PR DESCRIPTION
## Summary
- Adds a new instruction line to the Draw Quiz screen informing users they can strum from left-to-right to submit their answer

## Test plan
- [ ] Launch app and navigate to Draw Quiz mode
- [ ] Verify the instruction text shows "Strum from left-to-right to submit answer"

🤖 Generated with [Claude Code](https://claude.com/claude-code)