### PR TITLE
fix: keep screen on only for mic-active screens

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/MainActivity.kt
@@ -1,24 +1,88 @@
 package com.chordquiz.app.ui
 
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
+import android.os.PowerManager
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import com.chordquiz.app.ui.navigation.NavGraph
+import com.chordquiz.app.ui.navigation.NotePlayQuizRoute
+import com.chordquiz.app.ui.navigation.PlayQuizRoute
+import com.chordquiz.app.ui.navigation.TunerRoute
 import com.chordquiz.app.ui.theme.ChordQuizTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private var navController: NavHostController? = null
+    private var isPowerSaveModeActive = false
+
+    private val powerSaveReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == PowerManager.ACTION_POWER_SAVE_MODE_CHANGED) {
+                val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+                isPowerSaveModeActive = pm.isPowerSaveMode
+                updateScreenFlag()
+            }
+        }
+    }
+
+    private val destinationChangedListener =
+        NavController.OnDestinationChangedListener { _, destination, _ ->
+            updateScreenFlag(destination)
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         enableEdgeToEdge()
         setContent {
+            val controller = rememberNavController()
+            navController = controller
             ChordQuizTheme {
-                NavGraph()
+                NavGraph(navController = controller)
             }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        isPowerSaveModeActive = pm.isPowerSaveMode
+
+        registerReceiver(powerSaveReceiver, IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED))
+
+        navController?.addOnDestinationChangedListener(destinationChangedListener)
+
+        updateScreenFlag(navController?.currentDestination)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        navController?.removeOnDestinationChangedListener(destinationChangedListener)
+        unregisterReceiver(powerSaveReceiver)
+    }
+
+    private fun updateScreenFlag(destination: NavDestination? = navController?.currentDestination) {
+        val isWhitelisted = destination != null && (
+            destination.hasRoute<PlayQuizRoute>() ||
+            destination.hasRoute<NotePlayQuizRoute>() ||
+            destination.hasRoute<TunerRoute>()
+        )
+        if (isWhitelisted && !isPowerSaveModeActive) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
 }

--- a/app/src/main/java/com/chordquiz/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/navigation/NavGraph.kt
@@ -1,9 +1,9 @@
 package com.chordquiz.app.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.chordquiz.app.ui.screen.instrument.InstrumentSelectionScreen
 import com.chordquiz.app.ui.screen.library.ChordLibraryScreen
@@ -35,9 +35,7 @@ import com.chordquiz.app.ui.screen.results.ResultsScreen
 import com.chordquiz.app.ui.screen.settings.SettingsScreen
 
 @Composable
-fun NavGraph() {
-    val navController = rememberNavController()
-
+fun NavGraph(navController: NavHostController) {
     NavHost(navController = navController, startDestination = InstrumentSelectionRoute) {
 
         composable<InstrumentSelectionRoute> {


### PR DESCRIPTION
## Summary
- Replaces hardcoded `FLAG_KEEP_SCREEN_ON` in `MainActivity` with dynamic whitelist-based logic
- Screen stays awake only on `PlayQuizRoute`, `NotePlayQuizRoute`, and `TunerRoute` (mic-active screens)
- Yields to Battery Saver mode via a `BroadcastReceiver` listening for `ACTION_POWER_SAVE_MODE_CHANGED`
- Re-evaluates screen state in `onStart` for instant restoration when user returns to the app
- Hoists `navController` from `NavGraph` into `MainActivity` so the Activity owns the screen-state logic

## Test plan
- [ ] Navigate to PlayQuiz — screen should stay on
- [ ] Navigate to NotePlayQuiz — screen should stay on
- [ ] Navigate to Tuner — screen should stay on
- [ ] Navigate to Library/Settings/Home — screen should be allowed to dim
- [ ] Enable Battery Saver mode while on PlayQuiz — screen should be allowed to dim
- [ ] Leave app and return while on a whitelisted screen — screen brightens immediately

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)