### PR TITLE
fix: stabilize Tuner and align UI

### DIFF
--- a/app/src/main/java/com/chordquiz/app/audio/AudioRecorderManager.kt
+++ b/app/src/main/java/com/chordquiz/app/audio/AudioRecorderManager.kt
@@ -21,7 +21,7 @@ class AudioRecorderManager @Inject constructor() {
         const val BUFFER_SIZE_FACTOR = 2
     }
 
-    private var audioRecord: AudioRecord? = null
+    @Volatile private var audioRecord: AudioRecord? = null
 
     /**
      * Emits [ShortArray] PCM buffers continuously while the flow is collected.
@@ -55,15 +55,16 @@ class AudioRecorderManager @Inject constructor() {
                 }
             }
         } finally {
-            record.stop()
-            record.release()
             audioRecord = null
+            runCatching { record.stop() }
+            runCatching { record.release() }
         }
     }.flowOn(Dispatchers.IO)
 
     fun stop() {
-        audioRecord?.stop()
-        audioRecord?.release()
+        val record = audioRecord
         audioRecord = null
+        runCatching { record?.stop() }
+        runCatching { record?.release() }
     }
 }

--- a/app/src/main/java/com/chordquiz/app/audio/TunerStringMatcher.kt
+++ b/app/src/main/java/com/chordquiz/app/audio/TunerStringMatcher.kt
@@ -26,7 +26,7 @@ data class StringTuningState(
 object TunerStringMatcher {
 
     /** Cents range for the green "in tune" zone. */
-    private const val IN_TUNE_CENTS = 20f
+    private const val IN_TUNE_CENTS = 10f
 
     /** Cents range for the yellow zone (one semitone = 100 cents). */
     private const val YELLOW_CENTS = 100f

--- a/app/src/main/java/com/chordquiz/app/ui/components/MicrophoneStatusCard.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/MicrophoneStatusCard.kt
@@ -1,0 +1,52 @@
+package com.chordquiz.app.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared "listening" card used by both [PlayQuizScreen] and [TunerScreen].
+ *
+ * Shows a microphone icon + status label and an [AudioWaveform] driven by [amplitude].
+ */
+@Composable
+fun MicrophoneStatusCard(
+    isListening: Boolean,
+    amplitude: Float,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = if (isListening) "🎙 Listening..." else "✓ Got it",
+                    style = MaterialTheme.typography.titleSmall
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            AudioWaveform(
+                amplitude = amplitude,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/chordquiz/app/ui/components/tuner/TunerFretboardView.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/tuner/TunerFretboardView.kt
@@ -1,17 +1,19 @@
 package com.chordquiz.app.ui.components.tuner
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -20,20 +22,21 @@ import com.chordquiz.app.audio.StringTuningState
 import com.chordquiz.app.audio.TuningZone
 import com.chordquiz.app.data.model.Instrument
 import com.chordquiz.app.ui.theme.CorrectGreen
-import com.chordquiz.app.ui.theme.FretboardWood
 import com.chordquiz.app.ui.theme.IncorrectRed
 import com.chordquiz.app.ui.theme.NutBrown
 import com.chordquiz.app.ui.theme.SecondaryAmber
 import com.chordquiz.app.ui.theme.StringColor
 
 /**
- * Horizontal fretboard view for the Tuner screen.
+ * Vertical fretboard view for the Tuner screen.
  *
- * Strings run left-to-right (index 0 = lowest/thickest at bottom, matching physical
- * orientation when looking at the fretboard from the front). Open string note names
- * are drawn at the nut on the left. The active string glows in zone color:
- *   - Red (>1 semitone off), Yellow (within 1 semitone), Green (in tune ±20¢).
+ * Strings run top-to-bottom as vertical columns; frets are horizontal lines.
+ * String index 0 = lowest/thickest on the left, index N-1 = highest on the right
+ * (matching standard guitar tab orientation). Open string note names are drawn
+ * above the nut. The active string glows in zone color:
+ *   - Red  (>1 semitone off), Yellow (within 1 semitone), Green (in tune ±10¢).
  * Ambiguous strings glow yellow at 50% alpha.
+ * Background is white to match the Play Quiz screen style.
  */
 @Composable
 fun TunerFretboardView(
@@ -50,72 +53,83 @@ fun TunerFretboardView(
         modifier = modifier
             .fillMaxWidth()
             .height(fretboardHeight)
+            .background(Color.White)
     ) {
         val stringCount = instrument.stringCount
-        val nutWidth = 36f
-        val fretAreaStart = nutWidth + 16f
-        val fretAreaEnd = size.width - 16f
-        val fretAreaWidth = fretAreaEnd - fretAreaStart
 
-        // Vertical padding so strings don't touch the top/bottom edges
-        val verticalPad = size.height * 0.12f
-        val usableHeight = size.height - 2 * verticalPad
+        // Vertical padding so fret area doesn't touch top/bottom edges
+        val labelHeight = labelTextSize * 2f
+        val nutHeight   = 6f
+        val topPad      = labelHeight + nutHeight + 4f
+        val bottomPad   = 12f
+        val fretAreaTop    = topPad
+        val fretAreaBottom = size.height - bottomPad
+        val fretAreaHeight = fretAreaBottom - fretAreaTop
 
-        // String Y positions — index 0 at bottom (lowest/thickest), index N-1 at top
-        val stringYs = List(stringCount) { i ->
-            // Reverse: lowest string (index 0) at bottom
-            verticalPad + usableHeight * (stringCount - 1 - i) / (stringCount - 1).coerceAtLeast(1)
+        // Horizontal padding so strings don't touch the left/right edges
+        val horizontalPad = size.width * 0.06f
+        val usableWidth   = size.width - 2 * horizontalPad
+
+        // String X positions — index 0 at left (lowest/thickest), index N-1 at right
+        val stringXs = List(stringCount) { i ->
+            horizontalPad + usableWidth * i / (stringCount - 1).coerceAtLeast(1)
         }
 
-        // --- Fretboard background ---
-        drawRect(
-            color = FretboardWood,
-            topLeft = Offset(fretAreaStart, verticalPad),
-            size = androidx.compose.ui.geometry.Size(fretAreaWidth, usableHeight)
-        )
+        // --- White background (already applied via Modifier, but draw explicitly for Canvas) ---
+        drawRect(color = Color.White, topLeft = Offset.Zero, size = size)
 
-        // --- Nut ---
+        // --- Fretboard background (light wood tint between strings) ---
         drawRect(
-            color = NutBrown,
-            topLeft = Offset(fretAreaStart, verticalPad - 2f),
-            size = androidx.compose.ui.geometry.Size(6f, usableHeight + 4f)
+            color = Color(0xFFF5F0E8),
+            topLeft = Offset(horizontalPad, fretAreaTop),
+            size = Size(usableWidth, fretAreaHeight)
         )
 
         // --- Fret lines (5 visible frets) ---
         val fretCount = 5
-        for (f in 1..fretCount) {
-            val x = fretAreaStart + fretAreaWidth * f / fretCount
+        for (f in 0..fretCount) {
+            val y = fretAreaTop + fretAreaHeight * f / fretCount
             drawLine(
                 color = Color(0xFFB0BEC5),
-                start = Offset(x, verticalPad),
-                end = Offset(x, verticalPad + usableHeight),
-                strokeWidth = 1.5f
+                start = Offset(horizontalPad, y),
+                end   = Offset(horizontalPad + usableWidth, y),
+                strokeWidth = if (f == 0) 1f else 1.5f
             )
         }
+
+        // --- Nut ---
+        drawRect(
+            color = NutBrown,
+            topLeft = Offset(horizontalPad - 2f, fretAreaTop - nutHeight),
+            size = Size(usableWidth + 4f, nutHeight)
+        )
 
         // --- Strings and note labels ---
         for (i in 0 until stringCount) {
             val state = stringStates.getOrNull(i)
-            val y = stringYs[i]
+            val x = stringXs[i]
 
-            // String thickness: thicker strings at lower indices (physical guitar feel)
+            // String thickness: thicker strings at lower indices (physical feel)
             val baseThickness = 2f + (stringCount - 1 - i) * 0.5f
 
             val (strokeColor, strokeWidth, alpha) = resolveStringStyle(
-                state = state,
+                state         = state,
                 baseThickness = baseThickness
             )
 
             drawLine(
-                color = strokeColor.copy(alpha = alpha),
-                start = Offset(fretAreaStart + 6f, y),
-                end = Offset(fretAreaEnd, y),
+                color       = strokeColor.copy(alpha = alpha),
+                start       = Offset(x, fretAreaTop),
+                end         = Offset(x, fretAreaBottom),
                 strokeWidth = strokeWidth,
-                cap = StrokeCap.Round
+                cap         = StrokeCap.Round
             )
 
-            // Note label at the nut
-            val label = state?.openNote?.displayName ?: instrument.openStringNotes.getOrNull(i)?.displayName ?: ""
+            // Note label above the nut
+            val label = state?.openNote?.displayName
+                ?: instrument.openStringNotes.getOrNull(i)?.displayName
+                ?: ""
+
             val labelColor = when {
                 state?.isAmbiguous == true -> SecondaryAmber.copy(alpha = 0.7f)
                 state?.tuningZone == TuningZone.IN_TUNE -> CorrectGreen
@@ -127,12 +141,18 @@ fun TunerFretboardView(
             drawIntoCanvas { canvas ->
                 val paint = android.graphics.Paint().apply {
                     isAntiAlias = true
-                    textSize = labelTextSize
-                    color = labelColor.toArgb()
-                    textAlign = android.graphics.Paint.Align.CENTER
-                    typeface = android.graphics.Typeface.DEFAULT_BOLD
+                    textSize    = labelTextSize
+                    color       = labelColor.toArgb()
+                    textAlign   = android.graphics.Paint.Align.CENTER
+                    typeface    = android.graphics.Typeface.DEFAULT_BOLD
                 }
-                canvas.nativeCanvas.drawText(label, nutWidth / 2f, y + labelTextSize / 3f, paint)
+                // Draw label above the nut
+                canvas.nativeCanvas.drawText(
+                    label,
+                    x,
+                    fretAreaTop - nutHeight - 2f,
+                    paint
+                )
             }
         }
     }
@@ -146,12 +166,15 @@ private fun resolveStringStyle(
     if (state == null) return Triple(StringColor, baseThickness, 0.4f)
 
     return when {
-        state.isAmbiguous -> Triple(SecondaryAmber, baseThickness + 2f, 0.5f)
-        state.tuningZone == TuningZone.IN_TUNE -> Triple(CorrectGreen, baseThickness + 4f, 1f)
+        state.isAmbiguous ->
+            Triple(SecondaryAmber, baseThickness + 2f, 0.5f)
+        state.tuningZone == TuningZone.IN_TUNE ->
+            Triple(CorrectGreen, baseThickness + 4f, 1f)
         state.tuningZone == TuningZone.FLAT_YELLOW || state.tuningZone == TuningZone.SHARP_YELLOW ->
             Triple(SecondaryAmber, baseThickness + 2f, 1f)
         state.tuningZone == TuningZone.FLAT_RED || state.tuningZone == TuningZone.SHARP_RED ->
             Triple(IncorrectRed, baseThickness + 3f, 1f)
-        else -> Triple(StringColor, baseThickness, 0.5f)
+        else ->
+            Triple(StringColor, baseThickness, 0.5f)
     }
 }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/quizplay/PlayQuizScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/quizplay/PlayQuizScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,8 +23,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -52,7 +49,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chordquiz.app.data.model.QuizQuestion
-import com.chordquiz.app.ui.components.AudioWaveform
+import com.chordquiz.app.ui.components.MicrophoneStatusCard
 import com.chordquiz.app.ui.components.chord.ChordDiagram
 import com.chordquiz.app.ui.screen.settings.SettingsViewModel
 import com.chordquiz.app.ui.theme.CorrectGreen
@@ -165,38 +162,17 @@ fun PlayQuizScreen(
                     )
 
                     // Audio feedback area
-                    Card(
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    MicrophoneStatusCard(
+                        isListening = state.isListening,
+                        amplitude = amplitudeAnim
+                    )
+
+                    if (state.detectedNotes.isNotEmpty()) {
+                        Text(
+                            "Detected: ${state.detectedNotes.joinToString(" ") { it.displayNameFor(settings.noteDisplayMode) }}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                    ) {
-                        Column(
-                            modifier = Modifier.padding(16.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text = if (state.isListening) "🎙 Listening..." else "✓ Got it",
-                                    style = MaterialTheme.typography.titleSmall
-                                )
-                            }
-                            Spacer(Modifier.height(8.dp))
-
-                            AudioWaveform(
-                                amplitude = amplitudeAnim,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-
-                            if (state.detectedNotes.isNotEmpty()) {
-                                Spacer(Modifier.height(8.dp))
-                                Text(
-                                    "Detected: ${state.detectedNotes.joinToString(" ") { it.displayNameFor(settings.noteDisplayMode) }}",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                        }
                     }
 
                     // Feedback banner

--- a/app/src/main/java/com/chordquiz/app/ui/screen/tuner/TunerScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/tuner/TunerScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.chordquiz.app.ui.components.AudioWaveform
+import com.chordquiz.app.ui.components.MicrophoneStatusCard
 import com.chordquiz.app.ui.components.tuner.TunerFretboardView
 import com.chordquiz.app.ui.theme.CorrectGreen
 
@@ -137,16 +137,9 @@ fun TunerScreen(
                 }
 
                 // Listening indicator + waveform
-                Text(
-                    text = if (uiState.isListening) "Listening..." else "",
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                AudioWaveform(
-                    amplitude = amplitudeAnim,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.fillMaxWidth()
+                MicrophoneStatusCard(
+                    isListening = uiState.isListening,
+                    amplitude = amplitudeAnim
                 )
 
                 Spacer(Modifier.weight(1f))

--- a/app/src/main/java/com/chordquiz/app/ui/screen/tuner/TunerViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/tuner/TunerViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.max
 
 data class TunerUiState(
     val instrument: Instrument = Instrument.GUITAR,
@@ -43,6 +44,13 @@ class TunerViewModel @Inject constructor(
     private var listeningJob: Job? = null
     private var successDismissJob: Job? = null
     private var autoContinueDelaySeconds: Int = 2
+
+    /** Sliding window for median-filter smoothing of detected pitch (Hz). */
+    private val pitchWindow = ArrayDeque<Float>(MEDIAN_WINDOW)
+
+    companion object {
+        private const val MEDIAN_WINDOW = 5
+    }
 
     init {
         viewModelScope.launch {
@@ -72,7 +80,17 @@ class TunerViewModel @Inject constructor(
                 if (!state.isListening) return@collect
 
                 val amplitude = PitchDetector.computeAmplitude(buffer)
-                val detectedHz = TunerPitchDetector.detectPitch(buffer)
+
+                // While showing a success message, only update the amplitude so the
+                // waveform stays live without re-triggering detection.
+                if (state.successMessage != null) {
+                    _uiState.value = state.copy(amplitude = amplitude)
+                    return@collect
+                }
+
+                val rawHz = TunerPitchDetector.detectPitch(buffer)
+                val detectedHz = smoothPitch(rawHz)
+
                 val stringStates = TunerStringMatcher.match(detectedHz, state.instrument)
 
                 // Find the single active string (non-ambiguous, non-neutral)
@@ -99,16 +117,32 @@ class TunerViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Adds [rawHz] to the sliding window and returns the median, giving smooth
+     * pitch readings even when the FFT produces occasional outliers.
+     * Returns null when no pitch is detected (clears the window).
+     */
+    private fun smoothPitch(rawHz: Float?): Float? {
+        if (rawHz == null || rawHz <= 0f) {
+            pitchWindow.clear()
+            return null
+        }
+        if (pitchWindow.size >= MEDIAN_WINDOW) pitchWindow.removeFirst()
+        pitchWindow.addLast(rawHz)
+        val sorted = pitchWindow.sorted()
+        return sorted[sorted.size / 2]
+    }
+
     private fun onStringInTune(stringState: StringTuningState, instrument: Instrument) {
         val state = _uiState.value
         // Guard: don't re-trigger if a success message is already showing
         if (state.successMessage != null) return
 
         val message = "${stringState.openNote.displayName} string in Tune!"
+        // Keep isListening = true so the waveform stays live during the success overlay.
         _uiState.value = state.copy(
             successMessage = message,
-            guidanceText = null,
-            isListening = false
+            guidanceText = null
         )
 
         val midi = stringState.openNote.semitone + 12 * (stringState.octave + 1)
@@ -116,15 +150,18 @@ class TunerViewModel @Inject constructor(
             NotePlayer.playNote(midi, instrument.id)
         }
 
+        // Duration = 2× the user's auto-continue delay, minimum 2 000 ms.
+        val dismissDelay = max(autoContinueDelaySeconds * 2 * 1000L, 2000L)
         successDismissJob?.cancel()
         successDismissJob = viewModelScope.launch {
-            delay(autoContinueDelaySeconds * 1000L)
+            delay(dismissDelay)
             resetToIdle()
         }
     }
 
     private fun resetToIdle() {
         val inst = _uiState.value.instrument
+        pitchWindow.clear()
         _uiState.value = _uiState.value.copy(
             successMessage = null,
             guidanceText = null,


### PR DESCRIPTION
## Summary
- Fixes AudioRecorderManager double-release crash with volatile field + null-before-release pattern
- Tightens tuner in-tune tolerance to 10 cents and adds 5-sample median pitch filter
- Keeps waveform live during success overlay; dismiss duration = max(2×autoContinueDelay, 2 s)
- Redesigns TunerFretboardView as vertical (strings top-to-bottom, white background)
- Extracts shared `MicrophoneStatusCard` used by both PlayQuizScreen and TunerScreen

## Test plan
- [ ] Open Tuner, play an open string — green glow triggers at ±10¢ (tighter than before)
- [ ] Verify "in tune" success overlay shows and waveform keeps animating during display
- [ ] Verify success overlay lasts ≥2 s (scales with autoContinueDelay setting)
- [ ] Navigate away from Tuner mid-session — no crash on return or app exit
- [ ] Play Quiz screen still shows MicrophoneStatusCard correctly
- [ ] Fretboard is vertical with white background on Tuner screen

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)