### PR TITLE
feat: refactor InteractiveChordDiagram to LazyColumn for smooth scroll

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -1,22 +1,34 @@
 package com.chordquiz.app.ui.components.chord
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
@@ -33,27 +45,59 @@ import com.chordquiz.app.ui.theme.IncorrectRed
 import com.chordquiz.app.ui.theme.MutedGray
 import com.chordquiz.app.ui.theme.NutBrown
 import com.chordquiz.app.ui.theme.StringColor
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlin.math.abs
+import kotlin.math.sqrt
+
+// Height of each fret row in the LazyColumn (shows ~4-5 at a time in a 280 dp container).
+private val FRET_ITEM_HEIGHT = 52.dp
+
+// Height of the fixed above-nut row that is always visible above the scrolling area.
+private val NUT_AREA_HEIGHT = 36.dp
+
+// Horizontal padding fractions (relative to composable width).
+private const val LEFT_PAD_FRAC = 0.12f   // space for fret-number label
+private const val RIGHT_PAD_FRAC = 0.04f
+
+/** Returns the x-centre pixel of [stringIndex] for a composable of [width] px. */
+private fun stringX(stringIndex: Int, width: Float, stringCount: Int): Float {
+    val leftPad = width * LEFT_PAD_FRAC
+    val strArea = width * (1f - LEFT_PAD_FRAC - RIGHT_PAD_FRAC)
+    val spacing = strArea / (stringCount - 1).coerceAtLeast(1)
+    return leftPad + stringIndex * spacing
+}
+
+/** Returns the nearest string index for touch position [x] in a composable of [width] px. */
+private fun stringIndexAt(x: Float, width: Float, stringCount: Int): Int {
+    val leftPad = width * LEFT_PAD_FRAC
+    val strArea = width * (1f - LEFT_PAD_FRAC - RIGHT_PAD_FRAC)
+    val spacing = strArea / (stringCount - 1).coerceAtLeast(1)
+    return ((x - leftPad) / spacing).toInt().coerceIn(0, stringCount - 1)
+}
 
 /**
- * Tappable chord diagram.
- * Tap a fret position to toggle a finger dot on/off.
- * Tap above the nut to cycle a string: open → muted → open.
- * Drag right-to-left along a fret to draw a barre across multiple strings.
+ * Tappable chord diagram backed by a [LazyColumn] for smooth native scroll and fling.
  *
- * @param noteQuizMode             when true: disables mute/barre, treats fret=-1 as empty and
- *                                  fret=0 as an open-string dot; above-nut area toggles fret 0
- * @param hintPositions            (stringIndex, fret) pairs rendered as yellow hint dots
- * @param incorrectFrettedStrings  strings where the user placed a wrong-note finger (shown red)
- * @param incorrectMutedStrings    strings the user muted but shouldn't have (X shown red)
- * @param missedMuteStrings        strings that should be muted but the user left open/fretted
- *                                  (open-circle shown red as a hint)
- * @param onNoteSelected           called when a finger is placed (fret >= 0)
+ * - **Scroll**: LazyColumn handles vertical fling; [rememberSnapFlingBehavior] snaps to
+ *   the nearest fret wire after a fling, just like scrolling a web page.
+ * - **Tap**: Each fret row uses [awaitEachGesture] and only fires [onFingeringChanged] when the
+ *   finger lifts without exceeding the system touch-slop — so a scroll never places a note.
+ * - **Barre**: A right-to-left drag within a single fret row is classified as a barre gesture
+ *   (once horizontal movement exceeds touch-slop); the LazyColumn sees it as non-vertical and
+ *   does not scroll.
+ * - **Background**: White to match the Play Quiz screen.
+ * - **Rendering**: Static grid lines (fret wires + strings) are drawn with [drawWithCache], so
+ *   the geometry is cached across recompositions and only recomputed on size changes.
+ *
+ * @param noteQuizMode    When `true`: disables mute/barre; open-string area toggles fret=0 dots.
+ * @param hintPositions   (stringIndex, fret) pairs rendered as yellow hint dots.
+ * @param onNoteSelected  Called when a finger dot is placed (fret >= 0).
  */
 @Composable
 fun InteractiveChordDiagram(
     stringCount: Int,
-    displayedFrets: Int = 5,
-    baseFret: Int = 1,
     totalFrets: Int = 21,
     initialFingering: Fingering? = null,
     noteQuizMode: Boolean = false,
@@ -68,226 +112,399 @@ fun InteractiveChordDiagram(
     onNoteSelected: ((stringIndex: Int, fret: Int) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
-    var effectiveBaseFret by remember {
-        mutableStateOf(initialFingering?.baseFret ?: baseFret)
-    }
     val initialPositions = initialFingering?.positions
         ?: (0 until stringCount).map { StringPosition(it, 0) }
+    var positions by remember(stringCount) { mutableStateOf(initialPositions.toMutableList()) }
+    var barre by remember(stringCount) { mutableStateOf(initialFingering?.barre) }
 
-    var positions by remember(stringCount) {
-        mutableStateOf(initialPositions.toMutableList())
-    }
-    var barre by remember(stringCount) {
-        mutableStateOf(initialFingering?.barre)
-    }
+    // Barre drag bookkeeping: snapshot of positions at drag-start for rubber-band reversal.
+    var barreDragBase by remember { mutableStateOf<List<StringPosition>?>(null) }
+    var barreDragStartString by remember { mutableStateOf(0) }
 
+    val initialScroll = ((initialFingering?.baseFret ?: 1) - 1).coerceAtLeast(0)
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = initialScroll)
+    val snapBehavior = rememberSnapFlingBehavior(listState)
     val textMeasurer = rememberTextMeasurer()
 
-    var topPad = 0f
-    var leftPad = 0f
-    var effectiveLeftPad = 0f
-    var stringSpacing = 0f
-    var fretSpacing = 0f
-    var diagramHeight = 0f
+    // Propagate scroll-position changes to the parent once scrolling settles.
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex to listState.isScrollInProgress }
+            .filter { (_, scrolling) -> !scrolling }
+            .map { (index, _) -> index }
+            .distinctUntilChanged()
+            .collect { index ->
+                onFingeringChanged(Fingering(positions.toList(), barre, index + 1))
+            }
+    }
 
-    Canvas(
-        modifier = modifier
-            .aspectRatio(0.7f)
-            .padding(4.dp)
-            .pointerInput(stringCount, displayedFrets) {
-                awaitEachGesture {
-                    val down = awaitFirstDown(requireUnconsumed = false)
-                    if (stringSpacing == 0f) return@awaitEachGesture
+    // ── Shared tap handler ──────────────────────────────────────────────────
+    fun handleFretTap(stringIndex: Int, fretNumber: Int) {
+        val curBarre = barre
+        val tapOnBarre = curBarre != null &&
+            stringIndex in curBarre.fromString..curBarre.toString &&
+            fretNumber == curBarre.fret
 
-                    val startX = down.position.x
-                    val startY = down.position.y
-
-                    val rawString = ((startX - effectiveLeftPad) / stringSpacing).toInt()
-                    val touchDownString = rawString.coerceIn(0, stringCount - 1)
-                    val touchDownInFretGrid = startY >= topPad
-                    val rawFret = ((startY - topPad) / fretSpacing).toInt() + effectiveBaseFret
-                    val touchDownFret = rawFret.coerceIn(effectiveBaseFret, effectiveBaseFret + displayedFrets - 1)
-
-                    // Snapshot base positions before any barre drag:
-                    // strings previously absorbed by a barre are reset to open so
-                    // a new drag (or a short drag falling back to tap) starts clean.
-                    val existingBarre = barre
-                    val basePositions: List<StringPosition> = if (existingBarre != null) {
-                        positions.map { pos ->
-                            if (pos.stringIndex in existingBarre.fromString..existingBarre.toString)
-                                StringPosition(pos.stringIndex, 0)
-                            else pos
-                        }
-                    } else positions.toList()
-
-                    // Tap handler — defined here so it closes over all gesture-local variables
-                    // and can be called from both the "pure tap" and "short drag" paths.
-                    fun performTap() {
-                        if (!touchDownInFretGrid) {
-                            if (noteQuizMode) {
-                                // Note quiz: above-nut area toggles open-string dot (fret=0) on/off
-                                val cur = positions.firstOrNull { it.stringIndex == touchDownString }?.fret ?: -1
-                                val newFret = if (cur == 0) -1 else 0
-                                positions = positions.toMutableList().also { list ->
-                                    val idx = list.indexOfFirst { it.stringIndex == touchDownString }
-                                    if (idx >= 0) list[idx] = StringPosition(touchDownString, newFret)
-                                }
-                                onFingeringChanged(Fingering(positions.toList(), null, effectiveBaseFret))
-                                if (newFret == 0) onNoteSelected?.invoke(touchDownString, 0)
-                            } else {
-                                // Chord mode: toggle open ↔ muted
-                                val cur = positions.firstOrNull { it.stringIndex == touchDownString }?.fret ?: 0
-                                val newFret = if (cur == -1) 0 else -1
-                                positions = positions.toMutableList().also { list ->
-                                    val idx = list.indexOfFirst { it.stringIndex == touchDownString }
-                                    if (idx >= 0) list[idx] = StringPosition(touchDownString, newFret)
-                                }
-                                onFingeringChanged(Fingering(positions.toList(), barre, effectiveBaseFret))
-                                if (newFret == 0) onNoteSelected?.invoke(touchDownString, 0)
-                            }
-                            return
-                        }
-
-                        val currentBarre = barre
-                        if (currentBarre != null &&
-                            touchDownString in currentBarre.fromString..currentBarre.toString &&
-                            touchDownFret == currentBarre.fret
-                        ) {
-                            // Tap lands on an existing barre
-                            val isEndpoint = touchDownString == currentBarre.fromString ||
-                                touchDownString == currentBarre.toString
-                            if (isEndpoint) {
-                                // Shrink the barre span by detaching this endpoint string
-                                val newFrom = if (touchDownString == currentBarre.fromString)
-                                    currentBarre.fromString + 1 else currentBarre.fromString
-                                val newTo = if (touchDownString == currentBarre.toString)
-                                    currentBarre.toString - 1 else currentBarre.toString
-                                barre = if (newTo - newFrom >= 1)
-                                    BarreSegment(currentBarre.fret, newFrom, newTo)
-                                else null
-                                positions = positions.toMutableList().also { list ->
-                                    val idx = list.indexOfFirst { it.stringIndex == touchDownString }
-                                    if (idx >= 0) list[idx] = StringPosition(touchDownString, 0)
-                                }
-                            } else {
-                                // Middle of barre: remove the entire barre and its dots
-                                barre = null
-                                positions = positions.toMutableList().also { list ->
-                                    for (s in currentBarre.fromString..currentBarre.toString) {
-                                        val idx = list.indexOfFirst { it.stringIndex == s }
-                                        if (idx >= 0) list[idx] = StringPosition(s, 0)
-                                    }
-                                }
-                            }
-                            onFingeringChanged(Fingering(positions.toList(), barre, effectiveBaseFret))
-                            return
-                        }
-
-                        // Regular fret tap: toggle dot on/off
-                        val curPos = positions.firstOrNull { it.stringIndex == touchDownString }
-                        val emptyFret = if (noteQuizMode) -1 else 0
-                        val newFret = if (curPos?.fret == touchDownFret) emptyFret else touchDownFret
-                        positions = positions.toMutableList().also { list ->
-                            val idx = list.indexOfFirst { it.stringIndex == touchDownString }
-                            if (idx >= 0) list[idx] = StringPosition(touchDownString, newFret)
-                            else list.add(StringPosition(touchDownString, newFret))
-                        }
-                        onFingeringChanged(Fingering(positions.toList(), if (noteQuizMode) null else barre, effectiveBaseFret))
-                        if (newFret > 0) onNoteSelected?.invoke(touchDownString, newFret)
+        if (tapOnBarre) {
+            val isEndpoint = stringIndex == curBarre!!.fromString ||
+                stringIndex == curBarre.toString
+            if (isEndpoint) {
+                val newFrom = if (stringIndex == curBarre.fromString)
+                    curBarre.fromString + 1 else curBarre.fromString
+                val newTo = if (stringIndex == curBarre.toString)
+                    curBarre.toString - 1 else curBarre.toString
+                barre = if (newTo - newFrom >= 1)
+                    BarreSegment(curBarre.fret, newFrom, newTo) else null
+                positions = positions.toMutableList().also { list ->
+                    val idx = list.indexOfFirst { it.stringIndex == stringIndex }
+                    if (idx >= 0) list[idx] = StringPosition(stringIndex, 0)
+                }
+            } else {
+                barre = null
+                positions = positions.toMutableList().also { list ->
+                    for (s in curBarre!!.fromString..curBarre.toString) {
+                        val idx = list.indexOfFirst { it.stringIndex == s }
+                        if (idx >= 0) list[idx] = StringPosition(s, 0)
                     }
+                }
+            }
+            onFingeringChanged(Fingering(positions.toList(), barre, listState.firstVisibleItemIndex + 1))
+        } else {
+            val curPos = positions.firstOrNull { it.stringIndex == stringIndex }
+            val emptyFret = if (noteQuizMode) -1 else 0
+            val newFret = if (curPos?.fret == fretNumber) emptyFret else fretNumber
+            positions = positions.toMutableList().also { list ->
+                val idx = list.indexOfFirst { it.stringIndex == stringIndex }
+                if (idx >= 0) list[idx] = StringPosition(stringIndex, newFret)
+                else list.add(StringPosition(stringIndex, newFret))
+            }
+            onFingeringChanged(
+                Fingering(positions.toList(), if (noteQuizMode) null else barre,
+                    listState.firstVisibleItemIndex + 1)
+            )
+            if (newFret > 0) onNoteSelected?.invoke(stringIndex, newFret)
+        }
+    }
 
-                    var gestureClassified = false
-                    var isBarreDrag = false
+    fun handleAboveNutTap(stringIndex: Int) {
+        if (noteQuizMode) {
+            val cur = positions.firstOrNull { it.stringIndex == stringIndex }?.fret ?: -1
+            val newFret = if (cur == 0) -1 else 0
+            positions = positions.toMutableList().also { list ->
+                val idx = list.indexOfFirst { it.stringIndex == stringIndex }
+                if (idx >= 0) list[idx] = StringPosition(stringIndex, newFret)
+            }
+            onFingeringChanged(
+                Fingering(positions.toList(), null, listState.firstVisibleItemIndex + 1)
+            )
+            if (newFret == 0) onNoteSelected?.invoke(stringIndex, 0)
+        } else {
+            val cur = positions.firstOrNull { it.stringIndex == stringIndex }?.fret ?: 0
+            val newFret = if (cur == -1) 0 else -1
+            positions = positions.toMutableList().also { list ->
+                val idx = list.indexOfFirst { it.stringIndex == stringIndex }
+                if (idx >= 0) list[idx] = StringPosition(stringIndex, newFret)
+            }
+            onFingeringChanged(
+                Fingering(positions.toList(), barre, listState.firstVisibleItemIndex + 1)
+            )
+            if (newFret == 0) onNoteSelected?.invoke(stringIndex, 0)
+        }
+    }
 
-                    while (true) {
-                        val event = awaitPointerEvent()
-                        val pointer = event.changes.firstOrNull { it.id == down.id } ?: break
+    // ── Layout ──────────────────────────────────────────────────────────────
+    Column(modifier = modifier.background(Color.White)) {
 
-                        val dx = pointer.position.x - startX
-                        val dy = pointer.position.y - startY
+        // Fixed above-nut row with open/muted markers (always visible, never scrolls).
+        AboveNutRow(
+            stringCount = stringCount,
+            positions = positions,
+            noteQuizMode = noteQuizMode,
+            incorrectMutedStrings = incorrectMutedStrings,
+            missedMuteStrings = missedMuteStrings,
+            incorrectFrettedStrings = incorrectFrettedStrings,
+            onTap = { stringIndex -> handleAboveNutTap(stringIndex) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(NUT_AREA_HEIGHT)
+        )
 
-                        // Classify once horizontal movement reaches one full string spacing
-                        if (!gestureClassified &&
-                            kotlin.math.abs(dx) >= stringSpacing &&
-                            kotlin.math.abs(dx) > kotlin.math.abs(dy)
-                        ) {
-                            gestureClassified = true
-                            if (dx < 0 && touchDownInFretGrid && !noteQuizMode) {
-                                // Right-to-left drag in fret grid → barre mode (chord mode only)
-                                isBarreDrag = true
-                                barre = null
-                                positions = basePositions.toMutableList()
-                            } else {
-                                // Left-to-right drag, above-nut drag, or note quiz → bubble to parent
-                                break
+        // Scrollable fret area — only visible items are composed.
+        LazyColumn(
+            state = listState,
+            flingBehavior = snapBehavior,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        ) {
+            items(totalFrets) { fretIndex ->
+                val fretNumber = fretIndex + 1
+                FretItem(
+                    fretNumber = fretNumber,
+                    stringCount = stringCount,
+                    positions = positions,
+                    barre = barre,
+                    hintPositions = hintPositions,
+                    incorrectFrettedStrings = incorrectFrettedStrings,
+                    noteQuizMode = noteQuizMode,
+                    noteDisplayMode = noteDisplayMode,
+                    openStringNotes = openStringNotes,
+                    openStringOctaves = openStringOctaves,
+                    textMeasurer = textMeasurer,
+                    onTap = { stringIndex -> handleFretTap(stringIndex, fretNumber) },
+                    onBarreDragStart = { startString ->
+                        barreDragStartString = startString
+                        val curBarre = barre
+                        barreDragBase = if (curBarre != null) {
+                            positions.map { pos ->
+                                if (pos.stringIndex in curBarre.fromString..curBarre.toString)
+                                    StringPosition(pos.stringIndex, 0)
+                                else pos
                             }
-                        }
-
-                        // Classify once vertical movement reaches one full fret spacing
-                        if (!gestureClassified &&
-                            kotlin.math.abs(dy) >= fretSpacing &&
-                            kotlin.math.abs(dy) > kotlin.math.abs(dx)
-                        ) {
-                            gestureClassified = true
-                            val delta = if (dy < 0) 1 else -1  // swipe up → higher up neck
-                            val maxBaseFret = (totalFrets - displayedFrets + 1).coerceAtLeast(1)
-                            val newBase = (effectiveBaseFret + delta).coerceIn(1, maxBaseFret)
-                            if (newBase != effectiveBaseFret) {
-                                effectiveBaseFret = newBase
-                                onFingeringChanged(Fingering(positions.toList(), barre, newBase))
-                            }
-                            break
-                        }
-
-                        if (isBarreDrag) {
-                            pointer.consume()
-                            val rawCurrent = ((pointer.position.x - effectiveLeftPad) / stringSpacing).toInt()
-                            // Rubber-band: span from leftmost reached back to touchDownString
-                            val barreEndString = minOf(
-                                rawCurrent.coerceIn(0, stringCount - 1),
-                                touchDownString
-                            )
-
-                            if (barreEndString < touchDownString) {
-                                val span = barreEndString..touchDownString
-                                // Recompute from base each frame so rubber-band reversal is clean
-                                val newPositions = basePositions.map { pos ->
-                                    if (pos.stringIndex in span && pos.fret <= touchDownFret)
-                                        StringPosition(pos.stringIndex, touchDownFret)
+                        } else positions.toList()
+                        barre = null
+                        positions = (barreDragBase ?: positions.toList()).toMutableList()
+                    },
+                    onBarreDragUpdate = { currentString ->
+                        val base = barreDragBase
+                        if (base != null) {
+                            val barreEnd = minOf(currentString, barreDragStartString)
+                            if (barreEnd < barreDragStartString) {
+                                val span = barreEnd..barreDragStartString
+                                positions = base.map { pos ->
+                                    if (pos.stringIndex in span && pos.fret <= fretNumber)
+                                        StringPosition(pos.stringIndex, fretNumber)
                                     else pos
-                                }
-                                // Actual barre span = only strings that were absorbed (fret ≤ barreFret)
+                                }.toMutableList()
                                 val absorbed = span.filter { s ->
-                                    (basePositions.firstOrNull { it.stringIndex == s }?.fret ?: 0) <= touchDownFret
+                                    (base.firstOrNull { it.stringIndex == s }?.fret ?: 0) <= fretNumber
                                 }
                                 barre = if (absorbed.size >= 2)
-                                    BarreSegment(touchDownFret, absorbed.min(), absorbed.max())
+                                    BarreSegment(fretNumber, absorbed.min(), absorbed.max())
                                 else null
-                                positions = newPositions.toMutableList()
                             } else {
-                                // Dragged back to starting string
                                 barre = null
-                                positions = basePositions.toMutableList()
+                                positions = base.toMutableList()
+                            }
+                        }
+                    },
+                    onBarreDragEnd = {
+                        val finalBarre = barre
+                        if (finalBarre != null) {
+                            // Barre committed — propagate to parent.
+                            onFingeringChanged(
+                                Fingering(positions.toList(), finalBarre,
+                                    listState.firstVisibleItemIndex + 1)
+                            )
+                        } else {
+                            // Drag produced no barre (e.g. reversed back to start string) →
+                            // restore positions and treat the gesture as a tap.
+                            val base = barreDragBase
+                            if (base != null) {
+                                positions = base.toMutableList()
+                            }
+                            handleFretTap(barreDragStartString, fretNumber)
+                        }
+                        barreDragBase = null
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(FRET_ITEM_HEIGHT)
+                )
+            }
+        }
+    }
+}
+
+// ── Private composables ──────────────────────────────────────────────────────
+
+/**
+ * Fixed-height row drawn above the nut.  Shows open-circle / muted-X / open-dot markers
+ * and the nut bar.  Handles taps for open↔muted toggling (chord mode) or open-dot
+ * toggling (note-quiz mode).
+ */
+@Composable
+private fun AboveNutRow(
+    stringCount: Int,
+    positions: List<StringPosition>,
+    noteQuizMode: Boolean,
+    incorrectMutedStrings: Set<Int>,
+    missedMuteStrings: Set<Int>,
+    incorrectFrettedStrings: Set<Int>,
+    onTap: (stringIndex: Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Canvas(
+        modifier = modifier
+            .pointerInput(stringCount, noteQuizMode) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    val startX = down.position.x
+                    val startY = down.position.y
+                    var moved = false
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                        val dx = change.position.x - startX
+                        val dy = change.position.y - startY
+                        if (sqrt((dx * dx + dy * dy).toDouble()).toFloat() > viewConfiguration.touchSlop) {
+                            moved = true
+                            break
+                        }
+                        if (!change.pressed) {
+                            if (!moved) onTap(stringIndexAt(startX, size.width.toFloat(), stringCount))
+                            break
+                        }
+                    }
+                }
+            }
+    ) {
+        val leftPad = size.width * LEFT_PAD_FRAC
+        val strArea = size.width * (1f - LEFT_PAD_FRAC - RIGHT_PAD_FRAC)
+        val strSpacing = strArea / (stringCount - 1).coerceAtLeast(1)
+        val nutThickness = 5f
+
+        // String lines (above nut)
+        for (s in 0 until stringCount) {
+            val x = leftPad + s * strSpacing
+            drawLine(StringColor, Offset(x, 0f), Offset(x, size.height - nutThickness), 1.5f)
+        }
+
+        // Nut bar
+        drawRect(
+            color = NutBrown,
+            topLeft = Offset(leftPad, size.height - nutThickness),
+            size = Size(strArea, nutThickness)
+        )
+
+        // Open/muted/dot markers
+        val symbolY = size.height * 0.38f
+        val symbolR = minOf(size.width * 0.028f, size.height * 0.28f)
+
+        positions.forEach { pos ->
+            val x = leftPad + pos.stringIndex * strSpacing
+            if (noteQuizMode) {
+                if (pos.fret == 0) {
+                    drawCircle(FingerDot, symbolR, Offset(x, symbolY))
+                }
+            } else {
+                when (pos.fret) {
+                    -1 -> {
+                        val col = if (pos.stringIndex in incorrectMutedStrings) IncorrectRed else MutedGray
+                        drawLine(col, Offset(x - symbolR, symbolY - symbolR), Offset(x + symbolR, symbolY + symbolR), 2f)
+                        drawLine(col, Offset(x + symbolR, symbolY - symbolR), Offset(x - symbolR, symbolY + symbolR), 2f)
+                    }
+                    0 -> {
+                        val col = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings)
+                            IncorrectRed else Color.Black
+                        drawCircle(col, symbolR, Offset(x, symbolY), style = Stroke(2f))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One horizontal fret band in the LazyColumn.
+ *
+ * Static grid (fret wire + string lines) is drawn with [drawWithCache] so the geometry
+ * is computed once per size change and reused on every recomposition.
+ *
+ * Dynamic content (finger dots, barre, hint dots, note labels) is drawn in a Canvas
+ * layered on top.
+ *
+ * Gesture handling:
+ * - Movement ≤ touch-slop → [onTap] fires (note placement / barre shrink / removal).
+ * - Right-to-left horizontal movement > touch-slop → barre drag ([onBarreDragStart] /
+ *   [onBarreDragUpdate] / [onBarreDragEnd]).
+ * - Left-to-right or vertical movement > touch-slop → not consumed; the [LazyColumn]
+ *   handles vertical scroll; the parent's swipe-to-submit handles left-to-right.
+ */
+@Composable
+private fun FretItem(
+    fretNumber: Int,
+    stringCount: Int,
+    positions: List<StringPosition>,
+    barre: BarreSegment?,
+    hintPositions: Set<Pair<Int, Int>>,
+    incorrectFrettedStrings: Set<Int>,
+    noteQuizMode: Boolean,
+    noteDisplayMode: NoteDisplayMode,
+    openStringNotes: List<Note>,
+    openStringOctaves: List<Int>,
+    textMeasurer: TextMeasurer,
+    onTap: (stringIndex: Int) -> Unit,
+    onBarreDragStart: (startString: Int) -> Unit,
+    onBarreDragUpdate: (currentString: Int) -> Unit,
+    onBarreDragEnd: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            // ── Static grid (cached) ──────────────────────────────────────
+            .drawWithCache {
+                val leftPad  = size.width * LEFT_PAD_FRAC
+                val strArea  = size.width * (1f - LEFT_PAD_FRAC - RIGHT_PAD_FRAC)
+                val strSpacing = strArea / (stringCount - 1).coerceAtLeast(1)
+                // Pre-compute string x-positions once; reused every draw pass.
+                val strXs = List(stringCount) { s -> leftPad + s * strSpacing }
+
+                onDrawBehind {
+                    // Fret wire at top of this row
+                    drawLine(
+                        color = Color.Gray,
+                        start = Offset(leftPad, 0f),
+                        end = Offset(leftPad + strArea, 0f),
+                        strokeWidth = 1.5f
+                    )
+                    // String lines (vertical, full row height)
+                    for (x in strXs) {
+                        drawLine(StringColor, Offset(x, 0f), Offset(x, size.height), 1.5f)
+                    }
+                }
+            }
+            // ── Gesture handling ──────────────────────────────────────────
+            .pointerInput(fretNumber, stringCount, noteQuizMode) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    val startX = down.position.x
+                    val startY = down.position.y
+                    val startString = stringIndexAt(startX, size.width.toFloat(), stringCount)
+
+                    var classified      = false
+                    var barreDragActive = false
+
+                    while (true) {
+                        val event  = awaitPointerEvent()
+                        val change = event.changes.firstOrNull { it.id == down.id } ?: break
+
+                        val dx   = change.position.x - startX
+                        val dy   = change.position.y - startY
+                        val dist = sqrt((dx * dx + dy * dy).toDouble()).toFloat()
+
+                        if (!classified && dist > viewConfiguration.touchSlop) {
+                            classified = true
+                            val isHorizontal = abs(dx) >= abs(dy)
+                            when {
+                                !isHorizontal -> break  // vertical → LazyColumn scrolls
+                                dx < 0 && !noteQuizMode -> {
+                                    // Right-to-left horizontal → barre drag
+                                    barreDragActive = true
+                                    onBarreDragStart(startString)
+                                }
+                                else -> break  // left-to-right → swipe-to-submit in parent
                             }
                         }
 
-                        if (!pointer.pressed) {
-                            val committedBarre = barre
+                        if (barreDragActive) {
+                            change.consume()
+                            onBarreDragUpdate(stringIndexAt(change.position.x, size.width.toFloat(), stringCount))
+                        }
+
+                        if (!change.pressed) {
                             when {
-                                isBarreDrag && committedBarre != null -> {
-                                    // Commit the barre
-                                    onFingeringChanged(Fingering(positions.toList(), committedBarre, effectiveBaseFret))
-                                }
-                                isBarreDrag -> {
-                                    // Drag didn't reach 2+ strings → restore and treat as tap
-                                    positions = basePositions.toMutableList()
-                                    barre = existingBarre
-                                    performTap()
-                                }
-                                !gestureClassified -> {
-                                    // Pure tap
-                                    performTap()
-                                }
+                                !classified     -> onTap(startString)  // pure tap (≤ touchSlop)
+                                barreDragActive -> onBarreDragEnd()
                             }
                             break
                         }
@@ -295,185 +512,91 @@ fun InteractiveChordDiagram(
                 }
             }
     ) {
-        topPad = size.height * 0.12f
-        val bottomPad = size.height * 0.04f
-        leftPad = size.width * 0.14f
-        val rightPad = size.width * 0.06f
-        val fretLabelExtra = if (effectiveBaseFret > 1) size.width * 0.06f else 0f
-        effectiveLeftPad = leftPad + fretLabelExtra
+        // ── Dynamic content ────────────────────────────────────────────────
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val leftPad    = size.width * LEFT_PAD_FRAC
+            val strArea    = size.width * (1f - LEFT_PAD_FRAC - RIGHT_PAD_FRAC)
+            val strSpacing = strArea / (stringCount - 1).coerceAtLeast(1)
+            val midY       = size.height / 2f
+            val dotRadius  = size.height * 0.33f
 
-        val diagramWidth = size.width - effectiveLeftPad - rightPad
-        diagramHeight = size.height - topPad - bottomPad
-        stringSpacing = diagramWidth / (stringCount - 1)
-        fretSpacing = diagramHeight / displayedFrets
-
-        // Nut / fret number
-        if (effectiveBaseFret == 1) {
-            drawRect(
-                color = NutBrown,
-                topLeft = Offset(effectiveLeftPad, topPad - fretSpacing * 0.12f),
-                size = Size(diagramWidth, fretSpacing * 0.12f)
+            // Fret number label (left margin)
+            val labelText  = fretNumber.toString()
+            val labelStyle = TextStyle(
+                color     = Color.Gray,
+                fontSize  = (size.height * 0.32f / density).sp
             )
-        } else {
-            val labelText = "$effectiveBaseFret"
-            val labelStyle = TextStyle(color = Color.Black, fontSize = (size.height * 0.07f / density).sp)
-            val measured = textMeasurer.measure(labelText, style = labelStyle)
+            val labelMeasured = textMeasurer.measure(labelText, style = labelStyle)
             drawText(
                 textMeasurer = textMeasurer,
-                text = labelText,
-                topLeft = Offset(
-                    x = effectiveLeftPad - size.width * 0.12f,
-                    y = topPad - measured.size.height / 2f
+                text          = labelText,
+                topLeft       = Offset(
+                    x = (leftPad - labelMeasured.size.width) / 2f,
+                    y = midY - labelMeasured.size.height / 2f
                 ),
                 style = labelStyle
             )
-        }
 
-        // Fret lines
-        for (f in 0..displayedFrets) {
-            val y = topPad + f * fretSpacing
-            drawLine(Color.Gray, Offset(effectiveLeftPad, y), Offset(effectiveLeftPad + diagramWidth, y), 1.5f)
-        }
-
-        // String lines
-        for (s in 0 until stringCount) {
-            val x = effectiveLeftPad + s * stringSpacing
-            drawLine(StringColor, Offset(x, topPad), Offset(x, topPad + diagramHeight), 1.5f)
-        }
-
-        // Tap-target grid — drawn first so finger dots and barre render on top.
-        // Full dot radius always, for reliable tap accuracy.
-        for (s in 0 until stringCount) {
-            for (f in 0 until displayedFrets) {
-                val cx = effectiveLeftPad + s * stringSpacing
-                val cy = topPad + (f + 0.5f) * fretSpacing
-                drawCircle(Color.Gray.copy(alpha = 0.18f), fretSpacing * 0.35f, Offset(cx, cy))
-            }
-        }
-
-        // Above-nut markers (open circle or muted X, or filled dot in note quiz mode)
-        val symbolY = topPad - fretSpacing * 0.45f
-        val symbolRadius = size.width * 0.035f
-        positions.forEach { pos ->
-            val x = effectiveLeftPad + pos.stringIndex * stringSpacing
-            if (noteQuizMode) {
-                when (pos.fret) {
-                    0 -> {
-                        // Note quiz open-string dot — filled dot at nut row
-                        drawCircle(FingerDot, fretSpacing * 0.35f, Offset(x, symbolY))
-                    }
-                    // fret=-1 (empty) → draw nothing
-                }
-            } else {
-                when (pos.fret) {
-                    -1 -> {
-                        // Muted X — red if incorrectly muted, gray otherwise
-                        val xColor = if (pos.stringIndex in incorrectMutedStrings) IncorrectRed else MutedGray
-                        drawLine(xColor, Offset(x - symbolRadius, symbolY - symbolRadius),
-                            Offset(x + symbolRadius, symbolY + symbolRadius), 2f)
-                        drawLine(xColor, Offset(x + symbolRadius, symbolY - symbolRadius),
-                            Offset(x - symbolRadius, symbolY + symbolRadius), 2f)
-                    }
-                    0 -> {
-                        // Open circle — red if this string should have been muted or fretted, black otherwise
-                        val oColor = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings) IncorrectRed else Color.Black
-                        drawCircle(oColor, symbolRadius, Offset(x, symbolY), style = Stroke(2f))
-                    }
-                }
-            }
-        }
-
-        // Hint dots (yellow) — shown in note quiz mode for valid positions after wrong tap
-        if (hintPositions.isNotEmpty()) {
-            val hintColor = Color(0xFFFFCC00)
-            hintPositions.forEach { (stringIdx, fret) ->
-                val x = effectiveLeftPad + stringIdx * stringSpacing
-                if (fret == 0) {
-                    // Open-string hint dot at nut row
-                    drawCircle(hintColor, fretSpacing * 0.35f, Offset(x, symbolY))
-                } else if (fret in (effectiveBaseFret)..(effectiveBaseFret + displayedFrets - 1)) {
-                    val y = topPad + (fret - effectiveBaseFret + 0.5f) * fretSpacing
-                    drawCircle(hintColor, fretSpacing * 0.35f, Offset(x, y))
-                }
-            }
-        }
-
-        val visibleRange = effectiveBaseFret..(effectiveBaseFret + displayedFrets - 1)
-
-        // Barre (drawn before finger dots so dots render on top)
-        barre?.takeIf { it.fret in visibleRange }?.let { b ->
-            val y = topPad + (b.fret - effectiveBaseFret + 0.5f) * fretSpacing
-            val x1 = effectiveLeftPad + b.fromString * stringSpacing
-            val x2 = effectiveLeftPad + b.toString * stringSpacing
-            val barreRadius = fretSpacing * 0.35f
-            drawRoundRect(
-                color = BarreColor,
-                topLeft = Offset(x1, y - barreRadius),
-                size = Size(x2 - x1, barreRadius * 2),
-                cornerRadius = CornerRadius(barreRadius, barreRadius)
-            )
-        }
-
-        // Finger dots
-        positions.filter { it.fret > 0 && it.fret in visibleRange }.forEach { pos ->
-            val x = effectiveLeftPad + pos.stringIndex * stringSpacing
-            val y = topPad + (pos.fret - effectiveBaseFret + 0.5f) * fretSpacing
-            val dotColor = if (pos.stringIndex in incorrectFrettedStrings) IncorrectRed else FingerDot
-            drawCircle(dotColor, fretSpacing * 0.35f, Offset(x, y))
-        }
-
-        // Note labels
-        if (noteDisplayMode.showNotes() && openStringNotes.isNotEmpty() && openStringOctaves.isNotEmpty()) {
-            val noteFontSize = (fretSpacing * 0.22f / density).sp
-            val noteStyleOnDark  = TextStyle(color = Color.White, fontSize = noteFontSize)
-            val noteStyleOnLight = TextStyle(color = Color.Black, fontSize = noteFontSize)
-            val noteStyleMuted   = TextStyle(color = Color(0xFF666666), fontSize = noteFontSize)
-
-            // Unified grid: every fret × string position in the visible window
+            // Tap-target hint circles (very light, behind dots)
             for (s in 0 until stringCount) {
-                for (f in 0 until displayedFrets) {
-                    val actualFret = effectiveBaseFret + f
-                    val hasFingerDot = positions.any { it.stringIndex == s && it.fret == actualFret }
-                    val isInBarre   = barre?.let { b ->
-                        actualFret == b.fret && s in b.fromString..b.toString
-                    } ?: false
+                val cx = leftPad + s * strSpacing
+                drawCircle(Color.Gray.copy(alpha = 0.10f), dotRadius, Offset(cx, midY))
+            }
 
+            // Barre (drawn before finger dots so dots render on top)
+            barre?.takeIf { it.fret == fretNumber }?.let { b ->
+                val x1 = leftPad + b.fromString * strSpacing
+                val x2 = leftPad + b.toString  * strSpacing
+                drawRoundRect(
+                    color      = BarreColor,
+                    topLeft    = Offset(x1, midY - dotRadius),
+                    size       = Size(x2 - x1, dotRadius * 2),
+                    cornerRadius = CornerRadius(dotRadius, dotRadius)
+                )
+            }
+
+            // Finger dots
+            positions.filter { it.fret == fretNumber }.forEach { pos ->
+                val x        = leftPad + pos.stringIndex * strSpacing
+                val dotColor = if (pos.stringIndex in incorrectFrettedStrings) IncorrectRed else FingerDot
+                drawCircle(dotColor, dotRadius, Offset(x, midY))
+            }
+
+            // Hint dots (yellow)
+            hintPositions.filter { (_, f) -> f == fretNumber }.forEach { (s, _) ->
+                val x = leftPad + s * strSpacing
+                drawCircle(Color(0xFFFFCC00), dotRadius, Offset(x, midY))
+            }
+
+            // Note labels (when display mode is active)
+            if (noteDisplayMode.showNotes() && openStringNotes.isNotEmpty() && openStringOctaves.isNotEmpty()) {
+                val noteFontSize = (size.height * 0.26f / density).sp
+                val styleOnDark  = TextStyle(color = Color.White,          fontSize = noteFontSize)
+                val styleOnLight = TextStyle(color = Color(0xFF888888),    fontSize = noteFontSize)
+
+                for (s in 0 until stringCount) {
                     val openNote   = openStringNotes.getOrNull(s)   ?: continue
                     val openOctave = openStringOctaves.getOrNull(s) ?: continue
-                    val note   = openNote.plus(actualFret)
-                    val octave = openOctave + (openNote.semitone + actualFret) / 12
-                    val label  = note.displayNameFor(
-                        noteDisplayMode,
-                        octave.takeIf { noteDisplayMode.showOctave() }
+                    val note       = openNote.plus(fretNumber)
+                    val octave     = openOctave + (openNote.semitone + fretNumber) / 12
+                    val hasFingerDot = positions.any { it.stringIndex == s && it.fret == fretNumber }
+                    val isInBarre    = barre?.let { b ->
+                        fretNumber == b.fret && s in b.fromString..b.toString
+                    } ?: false
+
+                    val label   = note.displayNameFor(
+                        noteDisplayMode, octave.takeIf { noteDisplayMode.showOctave() }
                     )
-                    val style   = if (hasFingerDot || isInBarre) noteStyleOnDark else noteStyleMuted
-                    val cx      = effectiveLeftPad + s * stringSpacing
-                    val cy      = topPad + (f + 0.5f) * fretSpacing
+                    val style   = if (hasFingerDot || isInBarre) styleOnDark else styleOnLight
+                    val cx      = leftPad + s * strSpacing
                     val measured = textMeasurer.measure(label, style = style)
                     drawText(
                         textMeasurer = textMeasurer,
-                        text = label,
-                        topLeft = Offset(cx - measured.size.width / 2f, cy - measured.size.height / 2f),
-                        style = style
+                        text          = label,
+                        topLeft       = Offset(cx - measured.size.width / 2f, midY - measured.size.height / 2f),
+                        style         = style
                     )
                 }
-            }
-
-            // Above-nut labels (open strings and muted markers)
-            positions.forEach { pos ->
-                if (pos.fret != -1 && pos.fret != 0) return@forEach
-                val openNote   = openStringNotes.getOrNull(pos.stringIndex)   ?: return@forEach
-                val openOctave = openStringOctaves.getOrNull(pos.stringIndex) ?: return@forEach
-                val octave = openOctave + openNote.semitone / 12
-                val label  = openNote.displayNameFor(noteDisplayMode, octave.takeIf { noteDisplayMode.showOctave() })
-                val x       = effectiveLeftPad + pos.stringIndex * stringSpacing
-                val measured = textMeasurer.measure(label, style = noteStyleOnLight)
-                drawText(
-                    textMeasurer = textMeasurer,
-                    text = label,
-                    topLeft = Offset(x - measured.size.width / 2f, symbolY - measured.size.height / 2f),
-                    style = noteStyleOnLight
-                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaces the single large Canvas with `LazyColumn` + `rememberSnapFlingBehavior` so the fretboard scrolls natively and snaps to fret wires after a fling
- Extracts `AboveNutRow` (fixed above scroll area) and `FretItem` (one per LazyColumn item) — only 4-5 frets are composed at any time
- `FretItem` uses `Modifier.drawWithCache` for the static grid so string/fret wire geometry is computed once per size change
- Gesture separation: tap (≤ touchSlop) → note placement; right-to-left drag → barre; vertical/left-to-right drag → not consumed (LazyColumn scrolls / parent swipe-to-submit)
- White background; fret numbers shown on left margin of each row
- Removes `displayedFrets` and `baseFret` params (both callers used defaults); scroll position propagated back via `onFingeringChanged.baseFret`

## Test plan
- [ ] Draw Quiz: fretboard scrolls smoothly with inertia and snaps to fret boundaries
- [ ] Tap a fret position → finger dot placed correctly
- [ ] Tap existing dot → toggles off
- [ ] Right-to-left drag → barre drawn across strings
- [ ] Left-to-right drag (swipe) → triggers "Submit" flash
- [ ] Fretboard scrolls to initialFingering.baseFret on question change
- [ ] Note Draw Quiz: same tap behavior, no barre gesture
- [ ] White background visible

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)