### PR TITLE
fix: make all fretboard backgrounds transparent

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
@@ -21,7 +22,6 @@ import com.chordquiz.app.ui.theme.BarreColor
 import com.chordquiz.app.ui.theme.FingerDot
 import com.chordquiz.app.ui.theme.MutedGray
 import com.chordquiz.app.ui.theme.NutBrown
-import com.chordquiz.app.ui.theme.StringColor
 
 /**
  * Displays a read-only chord diagram for a given [ChordDefinition].
@@ -45,6 +45,14 @@ fun ChordDiagram(
 /**
  * Core Canvas-based chord diagram renderer.
  * Can be used for both static display and interactive overlays.
+ *
+ * The background is transparent — callers control the surface behind this composable.
+ * All structural strokes (strings, fret wires) use [MaterialTheme.colorScheme.onSurface]
+ * so they are legible in both light and dark mode.
+ *
+ * [stringLineColor] and [openColor] default to [Color.Unspecified], which causes the
+ * implementation to fall back to [MaterialTheme.colorScheme.onSurface].  Pass explicit
+ * values only when a specific override is needed.
  */
 @Composable
 fun ChordDiagramCanvas(
@@ -53,12 +61,16 @@ fun ChordDiagramCanvas(
     modifier: Modifier = Modifier,
     displayedFrets: Int = 5,
     dotColor: Color = FingerDot,
-    stringLineColor: Color = StringColor,
+    stringLineColor: Color = Color.Unspecified,
     nutColor: Color = NutBrown,
     barreColor: Color = BarreColor,
     mutedColor: Color = MutedGray,
-    openColor: Color = Color.Black
+    openColor: Color = Color.Unspecified
 ) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val effectiveStringColor = if (stringLineColor == Color.Unspecified) onSurface else stringLineColor
+    val effectiveOpenColor   = if (openColor == Color.Unspecified) onSurface else openColor
+
     val textMeasurer = rememberTextMeasurer()
     Canvas(
         modifier = modifier
@@ -90,7 +102,7 @@ fun ChordDiagramCanvas(
             )
         } else {
             val labelText = "$baseFret"
-            val labelStyle = TextStyle(color = Color.Black, fontSize = (size.height * 0.07f / density).sp)
+            val labelStyle = TextStyle(color = onSurface, fontSize = (size.height * 0.07f / density).sp)
             val measured = textMeasurer.measure(labelText, style = labelStyle)
             drawText(
                 textMeasurer = textMeasurer,
@@ -107,7 +119,7 @@ fun ChordDiagramCanvas(
         for (f in 0..displayedFrets) {
             val y = topPad + f * fretSpacing
             drawLine(
-                color = Color.Gray,
+                color = onSurface.copy(alpha = 0.4f),
                 start = Offset(effectiveLeftPad, y),
                 end = Offset(effectiveLeftPad + diagramWidth, y),
                 strokeWidth = if (f == 0 && baseFret == 1) 0f else 1.5f
@@ -118,7 +130,7 @@ fun ChordDiagramCanvas(
         for (s in 0 until stringCount) {
             val x = effectiveLeftPad + s * stringSpacing
             drawLine(
-                color = stringLineColor,
+                color = effectiveStringColor,
                 start = Offset(x, topPad),
                 end = Offset(x, topPad + diagramHeight),
                 strokeWidth = 1.5f
@@ -140,7 +152,7 @@ fun ChordDiagramCanvas(
                 }
                 pos.fret == 0 -> {
                     // Open circle
-                    drawCircle(openColor, symbolRadius, Offset(x, symbolY), style =
+                    drawCircle(effectiveOpenColor, symbolRadius, Offset(x, symbolY), style =
                         androidx.compose.ui.graphics.drawscope.Stroke(width = 2f))
                 }
             }

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -1,7 +1,6 @@
 package com.chordquiz.app.ui.components.chord
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
@@ -13,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -44,7 +44,6 @@ import com.chordquiz.app.ui.theme.FingerDot
 import com.chordquiz.app.ui.theme.IncorrectRed
 import com.chordquiz.app.ui.theme.MutedGray
 import com.chordquiz.app.ui.theme.NutBrown
-import com.chordquiz.app.ui.theme.StringColor
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
@@ -212,7 +211,7 @@ fun InteractiveChordDiagram(
     }
 
     // ── Layout ──────────────────────────────────────────────────────────────
-    Column(modifier = modifier.background(Color.White)) {
+    Column(modifier = modifier) {
 
         // Fixed above-nut row with open/muted markers (always visible, never scrolls).
         AboveNutRow(
@@ -333,6 +332,8 @@ private fun AboveNutRow(
     onTap: (stringIndex: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+
     Canvas(
         modifier = modifier
             .pointerInput(stringCount, noteQuizMode) {
@@ -366,7 +367,7 @@ private fun AboveNutRow(
         // String lines (above nut)
         for (s in 0 until stringCount) {
             val x = leftPad + s * strSpacing
-            drawLine(StringColor, Offset(x, 0f), Offset(x, size.height - nutThickness), 1.5f)
+            drawLine(onSurface, Offset(x, 0f), Offset(x, size.height - nutThickness), 1.5f)
         }
 
         // Nut bar
@@ -395,7 +396,7 @@ private fun AboveNutRow(
                     }
                     0 -> {
                         val col = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings)
-                            IncorrectRed else Color.Black
+                            IncorrectRed else onSurface
                         drawCircle(col, symbolR, Offset(x, symbolY), style = Stroke(2f))
                     }
                 }
@@ -439,6 +440,8 @@ private fun FretItem(
     onBarreDragEnd: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+
     Box(
         modifier = modifier
             // ── Static grid (cached) ──────────────────────────────────────
@@ -452,14 +455,14 @@ private fun FretItem(
                 onDrawBehind {
                     // Fret wire at top of this row
                     drawLine(
-                        color = Color.Gray,
+                        color = onSurface.copy(alpha = 0.4f),
                         start = Offset(leftPad, 0f),
                         end = Offset(leftPad + strArea, 0f),
                         strokeWidth = 1.5f
                     )
                     // String lines (vertical, full row height)
                     for (x in strXs) {
-                        drawLine(StringColor, Offset(x, 0f), Offset(x, size.height), 1.5f)
+                        drawLine(onSurface, Offset(x, 0f), Offset(x, size.height), 1.5f)
                     }
                 }
             }
@@ -523,7 +526,7 @@ private fun FretItem(
             // Fret number label (left margin)
             val labelText  = fretNumber.toString()
             val labelStyle = TextStyle(
-                color     = Color.Gray,
+                color     = onSurface.copy(alpha = 0.6f),
                 fontSize  = (size.height * 0.32f / density).sp
             )
             val labelMeasured = textMeasurer.measure(labelText, style = labelStyle)

--- a/app/src/main/java/com/chordquiz/app/ui/components/tuner/TunerFretboardView.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/tuner/TunerFretboardView.kt
@@ -1,7 +1,6 @@
 package com.chordquiz.app.ui.components.tuner
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
@@ -25,7 +24,6 @@ import com.chordquiz.app.ui.theme.CorrectGreen
 import com.chordquiz.app.ui.theme.IncorrectRed
 import com.chordquiz.app.ui.theme.NutBrown
 import com.chordquiz.app.ui.theme.SecondaryAmber
-import com.chordquiz.app.ui.theme.StringColor
 
 /**
  * Vertical fretboard view for the Tuner screen.
@@ -36,7 +34,10 @@ import com.chordquiz.app.ui.theme.StringColor
  * above the nut. The active string glows in zone color:
  *   - Red  (>1 semitone off), Yellow (within 1 semitone), Green (in tune ±10¢).
  * Ambiguous strings glow yellow at 50% alpha.
- * Background is white to match the Play Quiz screen style.
+ *
+ * The background is transparent — the Tuner screen's own background shows through.
+ * All structural strokes (fret lines, inactive strings) use
+ * [MaterialTheme.colorScheme.onSurface] for light/dark-mode adaptability.
  */
 @Composable
 fun TunerFretboardView(
@@ -47,13 +48,12 @@ fun TunerFretboardView(
 ) {
     val density = LocalDensity.current
     val labelTextSize = with(density) { 12.sp.toPx() }
-    val onSurfaceColor = MaterialTheme.colorScheme.onSurface
+    val onSurface = MaterialTheme.colorScheme.onSurface
 
     Canvas(
         modifier = modifier
             .fillMaxWidth()
             .height(fretboardHeight)
-            .background(Color.White)
     ) {
         val stringCount = instrument.stringCount
 
@@ -75,22 +75,12 @@ fun TunerFretboardView(
             horizontalPad + usableWidth * i / (stringCount - 1).coerceAtLeast(1)
         }
 
-        // --- White background (already applied via Modifier, but draw explicitly for Canvas) ---
-        drawRect(color = Color.White, topLeft = Offset.Zero, size = size)
-
-        // --- Fretboard background (light wood tint between strings) ---
-        drawRect(
-            color = Color(0xFFF5F0E8),
-            topLeft = Offset(horizontalPad, fretAreaTop),
-            size = Size(usableWidth, fretAreaHeight)
-        )
-
         // --- Fret lines (5 visible frets) ---
         val fretCount = 5
         for (f in 0..fretCount) {
             val y = fretAreaTop + fretAreaHeight * f / fretCount
             drawLine(
-                color = Color(0xFFB0BEC5),
+                color = onSurface.copy(alpha = if (f == 0) 0.3f else 0.4f),
                 start = Offset(horizontalPad, y),
                 end   = Offset(horizontalPad + usableWidth, y),
                 strokeWidth = if (f == 0) 1f else 1.5f
@@ -113,8 +103,9 @@ fun TunerFretboardView(
             val baseThickness = 2f + (stringCount - 1 - i) * 0.5f
 
             val (strokeColor, strokeWidth, alpha) = resolveStringStyle(
-                state         = state,
-                baseThickness = baseThickness
+                state              = state,
+                baseThickness      = baseThickness,
+                defaultStringColor = onSurface
             )
 
             drawLine(
@@ -135,7 +126,7 @@ fun TunerFretboardView(
                 state?.tuningZone == TuningZone.IN_TUNE -> CorrectGreen
                 state?.tuningZone in listOf(TuningZone.FLAT_RED, TuningZone.SHARP_RED) -> IncorrectRed
                 state?.tuningZone in listOf(TuningZone.FLAT_YELLOW, TuningZone.SHARP_YELLOW) -> SecondaryAmber
-                else -> onSurfaceColor.copy(alpha = 0.7f)
+                else -> onSurface.copy(alpha = 0.7f)
             }
 
             drawIntoCanvas { canvas ->
@@ -161,9 +152,10 @@ fun TunerFretboardView(
 /** Returns (color, strokeWidth, alpha) for a string based on its tuning state. */
 private fun resolveStringStyle(
     state: StringTuningState?,
-    baseThickness: Float
+    baseThickness: Float,
+    defaultStringColor: Color
 ): Triple<Color, Float, Float> {
-    if (state == null) return Triple(StringColor, baseThickness, 0.4f)
+    if (state == null) return Triple(defaultStringColor, baseThickness, 0.4f)
 
     return when {
         state.isAmbiguous ->
@@ -175,6 +167,6 @@ private fun resolveStringStyle(
         state.tuningZone == TuningZone.FLAT_RED || state.tuningZone == TuningZone.SHARP_RED ->
             Triple(IncorrectRed, baseThickness + 3f, 1f)
         else ->
-            Triple(StringColor, baseThickness, 0.5f)
+            Triple(defaultStringColor, baseThickness, 0.5f)
     }
 }


### PR DESCRIPTION
Closes #94

## Summary
- **`ChordDiagram.kt`**: Removed hardcoded `Color.Gray` / `Color.Black` for fret wires, fret-number labels, and open-circle symbols; all now use `MaterialTheme.colorScheme.onSurface`. `stringLineColor` and `openColor` parameters default to `Color.Unspecified` → `onSurface` fallback, so external callers can still override when needed.
- **`InteractiveChordDiagram.kt`**: Removed `Modifier.background(Color.White)` from the `Column` wrapper. String lines, fret wires (`drawWithCache`), and open-string circles in `AboveNutRow` / `FretItem` all now use `onSurface`. `StringColor` import removed.
- **`TunerFretboardView.kt`**: Removed `.background(Color.White)` modifier, removed both `drawRect` background fills (white canvas + `Color(0xFFF5F0E8)` wood tint). Fret lines and inactive string color now use `onSurface`. `resolveStringStyle()` receives `defaultStringColor: Color` (passed as `onSurface`) instead of the hardcoded `StringColor`.

Finger dots (`FingerDot`), barre bars (`BarreColor`), hint dots (yellow `0xFFFFCC00`), and tuning-zone glows (green/yellow/red) retain their distinct semantic colors for sufficient contrast on both light and dark surfaces.

## Test plan
- [ ] Build passes CI
- [ ] Chord diagram is transparent in Quiz, Library, and Results screens
- [ ] Interactive chord diagram is transparent in the chord editor
- [ ] Tuner fretboard lets the screen background show through
- [ ] All structural lines visible in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)