### PR TITLE
feat: replace ChordType filter chips with computed difficulty groups

### DIFF
--- a/app/src/main/java/com/chordquiz/app/data/repository/GroupsRepository.kt
+++ b/app/src/main/java/com/chordquiz/app/data/repository/GroupsRepository.kt
@@ -21,4 +21,6 @@ interface GroupsRepository {
     fun getChordIdsForGroup(groupId: Long): Flow<List<ChordDefinition>>
 
     suspend fun deleteChordsFromGroup(group: GroupEntity): Int
+
+    fun computeDifficultyGroups(instrumentId: String, chords: List<ChordDefinition>): List<GroupEntity>
 }

--- a/app/src/main/java/com/chordquiz/app/data/repository/GroupsRepositoryImpl.kt
+++ b/app/src/main/java/com/chordquiz/app/data/repository/GroupsRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.chordquiz.app.data.db.dao.ChordDao
 import com.chordquiz.app.data.db.dao.GroupDao
 import com.chordquiz.app.data.db.entity.GroupEntity
 import com.chordquiz.app.data.model.ChordDefinition
+import com.chordquiz.app.domain.ChordDifficultyCalculator
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -51,4 +52,7 @@ class GroupsRepositoryImpl @Inject constructor(
         if (chordIdsToRemove.isEmpty()) return 0
         return chordDao.deleteChordsById(chordIdsToRemove)
     }
+
+    override fun computeDifficultyGroups(instrumentId: String, chords: List<ChordDefinition>): List<GroupEntity> =
+        ChordDifficultyCalculator.buildDifficultyGroups(instrumentId, chords)
 }

--- a/app/src/main/java/com/chordquiz/app/domain/ChordDifficultyCalculator.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/ChordDifficultyCalculator.kt
@@ -1,0 +1,79 @@
+package com.chordquiz.app.domain
+
+import com.chordquiz.app.data.db.entity.GroupEntity
+import com.chordquiz.app.data.model.ChordDefinition
+
+object ChordDifficultyCalculator {
+
+    // Virtual group IDs (negative so they never collide with DB-generated IDs)
+    const val EASY_GROUP_ID = -1L
+    const val MODERATE_GROUP_ID = -2L
+    const val DIFFICULT_GROUP_ID = -3L
+
+    private const val EASY_MAX = 6
+    private const val MODERATE_MAX = 9
+
+    fun score(chord: ChordDefinition): Int {
+        val fingering = chord.fingerings.firstOrNull() ?: return 0
+
+        val frettedPositions = fingering.positions.filter { it.fret > 0 }
+
+        // Count fingers used (barre counts as one finger regardless of strings covered)
+        val fingersUsed = if (fingering.barre != null) {
+            // 1 for the barre + any additional pressed strings not part of the barre
+            val barreStrings = (fingering.barre.fromString..fingering.barre.toString).toSet()
+            val extraFingers = frettedPositions.count {
+                it.stringIndex !in barreStrings || it.fret != fingering.barre.fret
+            }
+            1 + extraFingers
+        } else {
+            frettedPositions.size
+        }
+
+        // Fret span across pressed strings
+        val frets = frettedPositions.map { it.fret }
+        val fretSpan = if (frets.size >= 2) frets.max() - frets.min() else 0
+
+        // Barre width penalty
+        val barreWidth = when {
+            fingering.barre == null -> 0
+            (fingering.barre.toString - fingering.barre.fromString + 1) >= 4 -> 3
+            (fingering.barre.toString - fingering.barre.fromString + 1) >= 2 -> 2
+            else -> 1
+        }
+
+        // Open strings (lower difficulty)
+        val openStrings = fingering.positions.count { it.fret == 0 }
+
+        // Movable chord bonus (no open strings = harder to orient)
+        val movableBonus = if (openStrings == 0 && frettedPositions.isNotEmpty()) 1 else 0
+
+        return fingersUsed + fretSpan + barreWidth - openStrings + movableBonus
+    }
+
+    fun difficultyLabel(chord: ChordDefinition): String = when {
+        score(chord) <= EASY_MAX -> "Easy"
+        score(chord) <= MODERATE_MAX -> "Moderate"
+        else -> "Difficult"
+    }
+
+    fun buildDifficultyGroups(instrumentId: String, chords: List<ChordDefinition>): List<GroupEntity> {
+        val easy = chords.filter { score(it) <= EASY_MAX }
+        val moderate = chords.filter { score(it) in (EASY_MAX + 1)..MODERATE_MAX }
+        val difficult = chords.filter { score(it) > MODERATE_MAX }
+
+        return buildList {
+            if (easy.isNotEmpty()) add(virtualGroup(EASY_GROUP_ID, instrumentId, "Easy", easy))
+            if (moderate.isNotEmpty()) add(virtualGroup(MODERATE_GROUP_ID, instrumentId, "Moderate", moderate))
+            if (difficult.isNotEmpty()) add(virtualGroup(DIFFICULT_GROUP_ID, instrumentId, "Difficult", difficult))
+        }
+    }
+
+    private fun virtualGroup(id: Long, instrumentId: String, name: String, chords: List<ChordDefinition>) =
+        GroupEntity(
+            id = id,
+            instrumentId = instrumentId,
+            name = name,
+            chordIds = chords.joinToString(",") { it.id }
+        )
+}

--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.chordquiz.app.data.model.ChordType
 import com.chordquiz.app.ui.components.chord.ChordDiagram
 import com.chordquiz.app.ui.screen.settings.SettingsViewModel
 import kotlinx.coroutines.delay
@@ -116,7 +115,6 @@ fun ChordLibraryScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     if (uiState.selectedChordIds.size >= 2
-                        && uiState.activeTypeFilter == null
                         && uiState.activeGroupFilter == null) {
                         OutlinedButton(
                             onClick = {
@@ -166,16 +164,25 @@ fun ChordLibraryScreen(
                     }
                 }
 
-                // Filter chips: All → custom groups (newest first) → preset types
+                // Filter chips: All → difficulty groups → custom groups (newest first)
                 FlowRow(
                     modifier = Modifier.padding(horizontal = 12.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     LibraryFilterChip(
                         label = "All",
-                        selected = uiState.activeTypeFilter == null && uiState.activeGroupFilter == null,
-                        onClick = { viewModel.setTypeFilter(null) }
+                        selected = uiState.activeGroupFilter == null,
+                        onClick = { viewModel.setGroupFilter(null) }
                     )
+                    uiState.difficultyGroups.forEach { group ->
+                        key(group.id) {
+                            LibraryFilterChip(
+                                label = group.toName(),
+                                selected = uiState.activeGroupFilter?.id == group.id,
+                                onClick = { viewModel.setGroupFilter(group) }
+                            )
+                        }
+                    }
                     uiState.customGroups.forEach { group ->
                         key(group.id) {
                             LibraryFilterChip(
@@ -185,13 +192,6 @@ fun ChordLibraryScreen(
                                 onLongClick = { viewModel.requestDeleteGroup(group) }
                             )
                         }
-                    }
-                    ChordType.entries.forEach { type ->
-                        LibraryFilterChip(
-                            label = type.displayName,
-                            selected = uiState.activeTypeFilter == type,
-                            onClick = { viewModel.setTypeFilter(type) }
-                        )
                     }
                 }
 

--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryViewModel.kt
@@ -4,10 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chordquiz.app.data.db.entity.GroupEntity
 import com.chordquiz.app.data.model.ChordDefinition
-import com.chordquiz.app.data.model.ChordType
 import com.chordquiz.app.data.model.Instrument
 import com.chordquiz.app.data.repository.GroupsRepository
 import com.chordquiz.app.data.repository.InstrumentRepository
+import com.chordquiz.app.domain.ChordDifficultyCalculator
 import com.chordquiz.app.domain.GetChordsForInstrumentUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -25,8 +25,8 @@ data class ChordLibraryUiState(
     val allChords: List<ChordDefinition> = emptyList(),
     val filteredChords: List<ChordDefinition> = emptyList(),
     val selectedChordIds: Set<String> = emptySet(),
-    val activeTypeFilter: ChordType? = null,
     val activeGroupFilter: GroupEntity? = null,
+    val difficultyGroups: List<GroupEntity> = emptyList(),
     val customGroups: List<GroupEntity> = emptyList(),
     val isLoading: Boolean = true,
     val deleteConfirmGroup: GroupEntity? = null,
@@ -48,7 +48,6 @@ class ChordLibraryViewModel @Inject constructor(
     private val _saveComplete = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val saveComplete: SharedFlow<Unit> = _saveComplete.asSharedFlow()
 
-    private val typeFilter = MutableStateFlow<ChordType?>(null)
     private val groupFilter = MutableStateFlow<GroupEntity?>(null)
 
     // Held across the async validation → save flow
@@ -61,27 +60,23 @@ class ChordLibraryViewModel @Inject constructor(
             val instrument = instrumentRepo.getInstrumentById(instrumentId) ?: return@launch
             combine(
                 getChordsForInstrument(instrumentId),
-                typeFilter,
                 groupFilter,
                 groupsRepository.getGroupsFlow(instrumentId)
-            ) { chords, typeF, groupF, groups ->
-                var filtered = chords
-                when {
-                    groupF != null -> {
-                        val groupIds = groupF.chordIdsList()
-                        filtered = chords.filter { it.id in groupIds }
-                    }
-                    typeF != null -> {
-                        filtered = chords.filter { it.chordType == typeF }
-                    }
+            ) { chords, groupF, customGroups ->
+                val difficultyGroups = groupsRepository.computeDifficultyGroups(instrumentId, chords)
+                val filtered = if (groupF != null) {
+                    val groupIds = groupF.chordIdsList()
+                    chords.filter { it.id in groupIds }
+                } else {
+                    chords
                 }
                 _uiState.value = _uiState.value.copy(
                     instrument = instrument,
                     allChords = chords,
                     filteredChords = filtered,
-                    activeTypeFilter = typeF,
                     activeGroupFilter = groupF,
-                    customGroups = groups.sortedByDescending { it.createdAt },
+                    difficultyGroups = difficultyGroups,
+                    customGroups = customGroups.sortedByDescending { it.createdAt },
                     isLoading = false
                 )
             }.collect {}
@@ -94,18 +89,8 @@ class ChordLibraryViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(selectedChordIds = current)
     }
 
-    fun setTypeFilter(type: ChordType?) {
-        val wasOnGroup = groupFilter.value != null
-        groupFilter.value = null
-        typeFilter.value = type
-        if (wasOnGroup) {
-            _uiState.value = _uiState.value.copy(selectedChordIds = emptySet())
-        }
-    }
-
     fun setGroupFilter(group: GroupEntity?) {
         val wasOnGroup = groupFilter.value != null
-        typeFilter.value = null
         groupFilter.value = group
         if (group != null) {
             val existingIds = _uiState.value.allChords.map { it.id }.toSet()
@@ -140,7 +125,9 @@ class ChordLibraryViewModel @Inject constructor(
         val trimmed = name.trim()
         if (trimmed.isBlank() || chordIds.size < 2) return
 
-        val isPreset = ChordType.entries.any { it.displayName.equals(trimmed, ignoreCase = true) }
+        val isPreset = trimmed.equals("Easy", ignoreCase = true) ||
+                trimmed.equals("Moderate", ignoreCase = true) ||
+                trimmed.equals("Difficult", ignoreCase = true)
         if (isPreset) {
             _uiState.value = _uiState.value.copy(
                 saveNameError = "This name is already used by a built-in group."


### PR DESCRIPTION
## Summary
- Adds `ChordDifficultyCalculator` in `domain/` that scores each chord's first fingering by finger count, fret span, barre width, open strings, and movability — bucketing chords into Easy (≤6), Moderate (7–9), and Difficult (≥10)
- Difficulty groups are virtual `GroupEntity` objects with negative IDs (-1/-2/-3), computed on demand and never written to the database
- `ChordLibraryViewModel` drops `typeFilter` / `activeTypeFilter: ChordType?` entirely; the 4-flow `combine()` collapses to 3 flows; `requestSaveGroup()` now guards against "Easy"/"Moderate"/"Difficult" as reserved names
- `ChordLibraryScreen` replaces the `ChordType.entries` preset chips with difficulty group chips (no long-press delete); custom groups retain long-press delete

## Test plan
- [ ] Open Chord Library for any instrument — confirm Easy / Moderate / Difficult chips appear
- [ ] Tap each difficulty chip — confirm grid filters to the expected chords
- [ ] Tap All — confirm all chords are shown again
- [ ] Long-press a difficulty chip — confirm nothing happens (no delete dialog)
- [ ] Long-press a custom group chip — confirm delete dialog still appears
- [ ] Attempt to save a group named "Easy", "Moderate", or "Difficult" — confirm error message
- [ ] Save a valid custom group — confirm it appears after the difficulty chips

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)