### PR TITLE
feat: add 'Only open strings' note display mode

### DIFF
--- a/app/src/main/java/com/chordquiz/app/domain/model/NoteDisplayMode.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/model/NoteDisplayMode.kt
@@ -1,13 +1,15 @@
 package com.chordquiz.app.domain.model
 
 enum class NoteDisplayMode {
-    NONE,         // ◌
-    SHARP,        // C#
-    FLAT,         // Bb
-    SHARP_OCTAVE, // C#4
-    FLAT_OCTAVE;  // Bb4
+    NONE,               // ◌
+    OPEN_STRINGS_ONLY,  // | open string names above nut only
+    SHARP,              // C#
+    FLAT,               // Bb
+    SHARP_OCTAVE,       // C#4
+    FLAT_OCTAVE;        // Bb4
 
-    fun showNotes(): Boolean = this != NONE
+    fun showNotes(): Boolean = this != NONE && this != OPEN_STRINGS_ONLY
+    fun showOpenStringsOnly(): Boolean = this == OPEN_STRINGS_ONLY
     fun useFlats(): Boolean = this == FLAT || this == FLAT_OCTAVE
     fun showOctave(): Boolean = this == SHARP_OCTAVE || this == FLAT_OCTAVE
 }

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -221,6 +221,10 @@ fun InteractiveChordDiagram(
             incorrectMutedStrings = incorrectMutedStrings,
             missedMuteStrings = missedMuteStrings,
             incorrectFrettedStrings = incorrectFrettedStrings,
+            noteDisplayMode = noteDisplayMode,
+            openStringNotes = openStringNotes,
+            openStringOctaves = openStringOctaves,
+            textMeasurer = textMeasurer,
             onTap = { stringIndex -> handleAboveNutTap(stringIndex) },
             modifier = Modifier
                 .fillMaxWidth()
@@ -329,6 +333,10 @@ private fun AboveNutRow(
     incorrectMutedStrings: Set<Int>,
     missedMuteStrings: Set<Int>,
     incorrectFrettedStrings: Set<Int>,
+    noteDisplayMode: NoteDisplayMode = NoteDisplayMode.NONE,
+    openStringNotes: List<Note> = emptyList(),
+    openStringOctaves: List<Int> = emptyList(),
+    textMeasurer: TextMeasurer? = null,
     onTap: (stringIndex: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -395,9 +403,28 @@ private fun AboveNutRow(
                         drawLine(col, Offset(x + symbolR, symbolY - symbolR), Offset(x - symbolR, symbolY + symbolR), 2f)
                     }
                     0 -> {
-                        val col = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings)
-                            IncorrectRed else onSurface
-                        drawCircle(col, symbolR, Offset(x, symbolY), style = Stroke(2f))
+                        if (noteDisplayMode.showOpenStringsOnly() && textMeasurer != null
+                            && pos.stringIndex < openStringNotes.size
+                            && pos.stringIndex < openStringOctaves.size) {
+                            // Draw note name instead of open-circle for open strings
+                            val note = openStringNotes[pos.stringIndex]
+                            val label = note.displayNameFor(noteDisplayMode)
+                            val labelStyle = TextStyle(
+                                color = onSurface.copy(alpha = 0.85f),
+                                fontSize = (symbolR * 2.2f / density).sp
+                            )
+                            val measured = textMeasurer.measure(label, style = labelStyle)
+                            drawText(
+                                textMeasurer = textMeasurer,
+                                text = label,
+                                topLeft = Offset(x - measured.size.width / 2f, symbolY - measured.size.height / 2f),
+                                style = labelStyle
+                            )
+                        } else {
+                            val col = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings)
+                                IncorrectRed else onSurface
+                            drawCircle(col, symbolR, Offset(x, symbolY), style = Stroke(2f))
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/settings/SettingsScreen.kt
@@ -228,6 +228,7 @@ fun NoteDisplayModeDropdown(
 ) {
     val options = linkedMapOf(
         NoteDisplayMode.NONE to "◌  None",
+        NoteDisplayMode.OPEN_STRINGS_ONLY to "|  Only open strings",
         NoteDisplayMode.SHARP to "C#  Sharps",
         NoteDisplayMode.FLAT to "Bb  Flats",
         NoteDisplayMode.SHARP_OCTAVE to "C#4  Sharps + Octave",


### PR DESCRIPTION
## Summary
- Adds `OPEN_STRINGS_ONLY` to the `NoteDisplayMode` enum, positioned between `NONE` and `SHARP`
- `showNotes()` returns `false` for this mode so the fretboard remains label-free; a new `showOpenStringsOnly()` helper returns `true` only for this mode
- The `AboveNutRow` composable now accepts `noteDisplayMode`, `openStringNotes`, `openStringOctaves`, and `textMeasurer`; when the mode is `OPEN_STRINGS_ONLY`, open strings display their note name (sharp format, no octave) in place of the open circle
- Adds `"|  Only open strings"` to the `NoteDisplayModeDropdown` in Settings between None and Sharps

## Test plan
- [ ] Open Settings → Notes on fretboard dropdown — confirm "| Only open strings" appears between None and Sharps
- [ ] Select "Only open strings" and open the Draw Quiz interactive diagram — confirm note names appear above the nut for open strings only (no labels on fretted strings)
- [ ] Tap a string to mute it — confirm the X still renders (not a note label)
- [ ] Switch back to None — confirm labels disappear
- [ ] Switch to Sharps — confirm labels appear on all fret rows as before

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)