### PR TITLE
feat: make barre lines wider in chord diagrams

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -163,7 +163,7 @@ fun ChordDiagramCanvas(
             val y = topPad + (barre.fret - baseFret + 0.5f) * fretSpacing
             val x1 = effectiveLeftPad + barre.fromString * stringSpacing
             val x2 = effectiveLeftPad + barre.toString * stringSpacing
-            val barreRadius = fretSpacing * 0.35f
+            val barreRadius = fretSpacing * 0.45f
             drawRoundRect(
                 color = barreColor,
                 topLeft = Offset(x1, y - barreRadius),


### PR DESCRIPTION
This PR addresses issue #95 by making barre lines wider in chord diagrams. The change increases the barre radius from 0.35f to 0.45f, resulting in thicker barre lines that are more visible and easier to see in chord diagrams.