### PR TITLE
Improve barre chord rendering visual impact

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -163,12 +163,17 @@ fun ChordDiagramCanvas(
             val y = topPad + (barre.fret - baseFret + 0.5f) * fretSpacing
             val x1 = effectiveLeftPad + barre.fromString * stringSpacing
             val x2 = effectiveLeftPad + barre.toString * stringSpacing
-            val barreRadius = fretSpacing * 0.45f
+            val dotRadius = fretSpacing * 0.35f
+            // Calculate the outer edges of the barre line - encompassing the first and last finger dots
+            val startX = x1 - dotRadius
+            val endX = x2 + dotRadius
+            val barreWidth = endX - startX
+            val barreHeight = dotRadius * 2
             drawRoundRect(
                 color = barreColor,
-                topLeft = Offset(x1, y - barreRadius),
-                size = Size(x2 - x1, barreRadius * 2),
-                cornerRadius = CornerRadius(barreRadius, barreRadius)
+                topLeft = Offset(startX, y - dotRadius),
+                size = Size(barreWidth, barreHeight),
+                cornerRadius = CornerRadius(dotRadius, dotRadius)
             )
         }
 

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -158,6 +158,15 @@ fun ChordDiagramCanvas(
             }
         }
 
+        // Draw finger dots
+        fingering.positions
+            .filter { it.fret > 0 }
+            .forEach { pos ->
+                val x = effectiveLeftPad + pos.stringIndex * stringSpacing
+                val y = topPad + (pos.fret - baseFret + 0.5f) * fretSpacing
+                drawCircle(dotColor, fretSpacing * 0.35f, Offset(x, y))
+            }
+
         // Draw barre
         fingering.barre?.let { barre ->
             val y = topPad + (barre.fret - baseFret + 0.5f) * fretSpacing
@@ -176,14 +185,5 @@ fun ChordDiagramCanvas(
                 cornerRadius = CornerRadius(dotRadius, dotRadius)
             )
         }
-
-        // Draw finger dots
-        fingering.positions
-            .filter { it.fret > 0 }
-            .forEach { pos ->
-                val x = effectiveLeftPad + pos.stringIndex * stringSpacing
-                val y = topPad + (pos.fret - baseFret + 0.5f) * fretSpacing
-                drawCircle(dotColor, fretSpacing * 0.35f, Offset(x, y))
-            }
     }
 }

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -20,6 +20,7 @@ import com.chordquiz.app.data.model.ChordDefinition
 import com.chordquiz.app.data.model.Fingering
 import com.chordquiz.app.ui.theme.BarreColor
 import com.chordquiz.app.ui.theme.FingerDot
+import com.chordquiz.app.ui.theme.IncorrectRed
 import com.chordquiz.app.ui.theme.MutedGray
 import com.chordquiz.app.ui.theme.NutBrown
 
@@ -65,7 +66,8 @@ fun ChordDiagramCanvas(
     nutColor: Color = NutBrown,
     barreColor: Color = BarreColor,
     mutedColor: Color = MutedGray,
-    openColor: Color = Color.Unspecified
+    openColor: Color = Color.Unspecified,
+    incorrectFrettedStrings: Set<Int> = emptySet()
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
     val effectiveStringColor = if (stringLineColor == Color.Unspecified) onSurface else stringLineColor

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -178,8 +178,20 @@ fun ChordDiagramCanvas(
             val endX = x2 + dotRadius
             val barreWidth = endX - startX
             val barreHeight = dotRadius * 2
+
+            // Check if any finger dots beneath this barre are red (incorrect)
+            val barreColorToUse = if (fingering.positions.any {
+                it.fret > 0 &&
+                it.stringIndex in barre.fromString..barre.toString &&
+                it.stringIndex in incorrectFrettedStrings
+            }) {
+                IncorrectRed
+            } else {
+                barreColor
+            }
+
             drawRoundRect(
-                color = barreColor,
+                color = barreColorToUse,
                 topLeft = Offset(startX, y - dotRadius),
                 size = Size(barreWidth, barreHeight),
                 cornerRadius = CornerRadius(dotRadius, dotRadius)

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -573,23 +573,27 @@ private fun FretItem(
                 drawCircle(Color.Gray.copy(alpha = 0.10f), dotRadius, Offset(cx, midY))
             }
 
-            // Barre (drawn before finger dots so dots render on top)
-            barre?.takeIf { it.fret == fretNumber }?.let { b ->
-                val x1 = leftPad + b.fromString * strSpacing
-                val x2 = leftPad + b.toString  * strSpacing
-                drawRoundRect(
-                    color      = BarreColor,
-                    topLeft    = Offset(x1, midY - dotRadius),
-                    size       = Size(x2 - x1, dotRadius * 2),
-                    cornerRadius = CornerRadius(dotRadius, dotRadius)
-                )
-            }
-
             // Finger dots
             positions.filter { it.fret == fretNumber }.forEach { pos ->
                 val x        = leftPad + pos.stringIndex * strSpacing
                 val dotColor = if (pos.stringIndex in incorrectFrettedStrings) IncorrectRed else FingerDot
                 drawCircle(dotColor, dotRadius, Offset(x, midY))
+            }
+
+            // Barre (drawn after finger dots so barre covers them)
+            barre?.takeIf { it.fret == fretNumber }?.let { b ->
+                val x1 = leftPad + b.fromString * strSpacing
+                val x2 = leftPad + b.toString  * strSpacing
+                val dotRadius = size.height * 0.33f
+                // Calculate the outer edges of the barre line - encompassing the first and last finger dots
+                val startX = x1 - dotRadius
+                val endX = x2 + dotRadius
+                drawRoundRect(
+                    color      = BarreColor,
+                    topLeft    = Offset(startX, midY - dotRadius),
+                    size       = Size(endX - startX, dotRadius * 2),
+                    cornerRadius = CornerRadius(dotRadius, dotRadius)
+                )
             }
 
             // Hint dots (yellow)

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -588,8 +588,20 @@ private fun FretItem(
                 // Calculate the outer edges of the barre line - encompassing the first and last finger dots
                 val startX = x1 - dotRadius
                 val endX = x2 + dotRadius
+
+                // Check if any finger dots beneath this barre are red (incorrect)
+                val barreColorToUse = if (positions.any {
+                    it.fret == fretNumber &&
+                    it.stringIndex in b.fromString..b.toString &&
+                    it.stringIndex in incorrectFrettedStrings
+                }) {
+                    IncorrectRed
+                } else {
+                    BarreColor
+                }
+
                 drawRoundRect(
-                    color      = BarreColor,
+                    color      = barreColorToUse,
                     topLeft    = Offset(startX, midY - dotRadius),
                     size       = Size(endX - startX, dotRadius * 2),
                     cornerRadius = CornerRadius(dotRadius, dotRadius)


### PR DESCRIPTION
This PR addresses issue #95 by improving the visual impact of barre chords in chord diagrams.

## Changes Made:

1. **ChordDiagram.kt**:
   - Updated drawBarre function to encompass outer edges of first and last finger dots
   - Set barre thickness to match finger dot diameter (dotRadius * 2)
   - Applied drawRoundRect for capsule styling with matching corner radius
   - Ensured proper drawing order (barre over finger dots)

2. **InteractiveChordDiagram.kt**:
   - Applied the same improved barre rendering logic
   - Maintained consistent sizing and styling
   - Fixed drawing order to properly obscure finger dots

## Visual Improvements:
- Barre chords now render with better visual impact
- Barre lines properly encompass outer edges of finger dots
- Consistent thickness matching finger dot diameter
- Capsule styling with circular radius matching finger dots
- Correct layering effect where barre obscures covered finger dots

These changes make barre chords more visually distinct and impactful as requested in the issue.