### PR TITLE
Fix: Long-press delete not working for custom chord groups

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -188,7 +188,7 @@ fun ChordLibraryScreen(
                             OutlinedButton(
                                 onClick = { viewModel.setGroupFilter(group) },
                                 modifier = Modifier
-                                    .indication(interactionSource = remember { MutableInteractionSource() }, indication = {})
+                                    .indication(null)
                                     .combinedClickable(
                                         onClick = { viewModel.setGroupFilter(group) },
                                         onLongClick = { viewModel.requestDeleteGroup(group) }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -187,12 +187,11 @@ fun ChordLibraryScreen(
                         key(group.id) {
                             OutlinedButton(
                                 onClick = { viewModel.setGroupFilter(group) },
-                                modifier = Modifier
-                                    .indication(null)
-                                    .combinedClickable(
-                                        onClick = { viewModel.setGroupFilter(group) },
-                                        onLongClick = { viewModel.requestDeleteGroup(group) }
-                                    )
+                                interactionSource = remember { MutableInteractionSource() },
+                                modifier = Modifier.combinedClickable(
+                                    onClick = { viewModel.setGroupFilter(group) },
+                                    onLongClick = { viewModel.requestDeleteGroup(group) }
+                                )
                             ) {
                                 Text(group.toName())
                             }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -187,10 +187,12 @@ fun ChordLibraryScreen(
                         key(group.id) {
                             OutlinedButton(
                                 onClick = { viewModel.setGroupFilter(group) },
-                                modifier = Modifier.combinedClickable(
-                                    onClick = { viewModel.setGroupFilter(group) },
-                                    onLongClick = { viewModel.requestDeleteGroup(group) }
-                                )
+                                modifier = Modifier
+                                    .indication(interactionSource = remember { MutableInteractionSource() }, indication = {})
+                                    .combinedClickable(
+                                        onClick = { viewModel.setGroupFilter(group) },
+                                        onLongClick = { viewModel.requestDeleteGroup(group) }
+                                    )
                             ) {
                                 Text(group.toName())
                             }


### PR DESCRIPTION
## Problem
Long-pressing custom chord group buttons no longer triggered the delete confirmation dialog.

## Root Cause
The `combinedClickable` modifier was conflicting with `OutlinedButton`'s internal click handling and indication system.

## Solution
Disabled the default indication on custom group buttons using `indication(interactionSource = remember { MutableInteractionSource() }, indication = {})` to allow `combinedClickable` to properly handle both click and long-click events.