### PR TITLE
Fix: Long-press delete not working for custom chord groups and saved patterns

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -186,8 +186,7 @@ fun ChordLibraryScreen(
                     uiState.customGroups.forEach { group ->
                         key(group.id) {
                             OutlinedButton(
-                                onClick = { viewModel.setGroupFilter(group) },
-                                interactionSource = remember { MutableInteractionSource() },
+                                onClick = { /* disabled - handled by combinedClickable */ },
                                 modifier = Modifier.combinedClickable(
                                     onClick = { viewModel.setGroupFilter(group) },
                                     onLongClick = { viewModel.requestDeleteGroup(group) }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeScreen.kt
@@ -158,7 +158,7 @@ fun StrumPracticeScreen(
                     // Saved pattern buttons
                     uiState.savedPatterns.forEach { pattern ->
                         OutlinedButton(
-                            onClick = { viewModel.loadPattern(pattern) },
+                            onClick = { /* disabled - handled by combinedClickable */ },
                             modifier = Modifier.combinedClickable(
                                 onClick = { viewModel.loadPattern(pattern) },
                                 onLongClick = { viewModel.requestDeletePattern(pattern) }


### PR DESCRIPTION
## Summary
- Fixed long-press delete not triggering for custom chord groups in ChordLibraryScreen
- Fixed long-press delete not triggering for saved patterns in StrumPracticeScreen

## Root Cause
OutlinedButton's internal onClick handler was consuming touch events before the combinedClickable modifier could detect long-press gestures.

## Solution
Disabled OutlinedButton's onClick parameter and let combinedClickable handle all interactions (both click and long-press).

## Testing
- Long-press custom chord group → delete confirmation dialog appears
- Long-press saved pattern → delete confirmation dialog appears
- Tap still works correctly for filtering/loading