### PR TITLE
Make all buttons full screen width

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/instrument/InstrumentSelectionScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/instrument/InstrumentSelectionScreen.kt
@@ -159,11 +159,11 @@ private fun QuizTypeButton(
     onClick: () -> Unit
 ) {
     if (isSelected) {
-        Button(onClick = onClick) {
+        Button(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
             Text(label)
         }
     } else {
-        OutlinedButton(onClick = onClick) {
+        OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
             Text(label)
         }
     }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -119,7 +119,8 @@ fun ChordLibraryScreen(
                             onClick = {
                                 dialogInitialName = ""
                                 showSaveDialog = true
-                            }
+                            },
+                            modifier = Modifier.weight(1f)
                         ) {
                             Text("Save")
                         }
@@ -127,7 +128,8 @@ fun ChordLibraryScreen(
                     Button(
                         onClick = {
                             onStartPractice(instrumentId, uiState.selectedChordIds.toList())
-                        }
+                        },
+                        modifier = Modifier.weight(1f)
                     ) {
                         Text("Start →")
                     }
@@ -157,27 +159,40 @@ fun ChordLibraryScreen(
                         text = "${uiState.selectedChordIds.size} selected",
                         style = MaterialTheme.typography.bodyMedium
                     )
-                    Row {
-                        TextButton(onClick = { viewModel.selectAll() }) { Text("All") }
-                        TextButton(onClick = { viewModel.clearSelection() }) { Text("None") }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        TextButton(
+                            onClick = { viewModel.selectAll() },
+                            modifier = Modifier.weight(1f)
+                        ) { Text("All") }
+                        TextButton(
+                            onClick = { viewModel.clearSelection() },
+                            modifier = Modifier.weight(1f)
+                        ) { Text("None") }
                     }
                 }
 
                 // Filter buttons: All → difficulty groups → custom groups (newest first)
                 @OptIn(ExperimentalFoundationApi::class)
                 FlowRow(
-                    modifier = Modifier.padding(horizontal = 12.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     OutlinedButton(
-                        onClick = { viewModel.setGroupFilter(null) }
+                        onClick = { viewModel.setGroupFilter(null) },
+                        modifier = Modifier.fillMaxWidth()
                     ) {
                         Text("All")
                     }
                     uiState.difficultyGroups.forEach { group ->
                         key(group.id) {
                             OutlinedButton(
-                                onClick = { viewModel.setGroupFilter(group) }
+                                onClick = { viewModel.setGroupFilter(group) },
+                                modifier = Modifier.fillMaxWidth()
                             ) {
                                 Text(group.toName())
                             }
@@ -187,6 +202,7 @@ fun ChordLibraryScreen(
                         key(group.id) {
                             Box(
                                 modifier = Modifier
+                                    .fillMaxWidth()
                                     .pointerInput(group.id) {
                                         detectTapGestures(
                                             onLongPress = {
@@ -196,7 +212,8 @@ fun ChordLibraryScreen(
                                     }
                             ) {
                                 OutlinedButton(
-                                    onClick = { viewModel.setGroupFilter(group) }
+                                    onClick = { viewModel.setGroupFilter(group) },
+                                    modifier = Modifier.fillMaxWidth()
                                 ) {
                                     Text(group.toName())
                                 }
@@ -307,16 +324,20 @@ fun ChordLibraryScreen(
                                 groupName, instrumentId, uiState.selectedChordIds.toList()
                             )
                         },
+                        modifier = Modifier.fillMaxWidth(),
                         enabled = groupName.isNotBlank() && uiState.selectedChordIds.size >= 2
                     ) {
                         Text("Save")
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = {
-                        showSaveDialog = false
-                        viewModel.clearSaveNameError()
-                    }) {
+                    TextButton(
+                        onClick = {
+                            showSaveDialog = false
+                            viewModel.clearSaveNameError()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
                         Text("Cancel")
                     }
                 }
@@ -334,15 +355,21 @@ fun ChordLibraryScreen(
                     )
                 },
                 confirmButton = {
-                    Button(onClick = {
-                        viewModel.confirmReplaceGroup()
-                        showSaveDialog = false
-                    }) {
+                    Button(
+                        onClick = {
+                            viewModel.confirmReplaceGroup()
+                            showSaveDialog = false
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
                         Text("Yes")
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = { viewModel.cancelReplaceGroup() }) {
+                    TextButton(
+                        onClick = { viewModel.cancelReplaceGroup() },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
                         Text("No")
                     }
                 }
@@ -355,12 +382,18 @@ fun ChordLibraryScreen(
                 onDismissRequest = { viewModel.cancelDeleteGroup() },
                 title = { Text("Delete group ${group.toName()}?") },
                 confirmButton = {
-                    Button(onClick = { viewModel.confirmDeleteGroup() }) {
+                    Button(
+                        onClick = { viewModel.confirmDeleteGroup() },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
                         Text("Delete")
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = { viewModel.cancelDeleteGroup() }) {
+                    TextButton(
+                        onClick = { viewModel.cancelDeleteGroup() },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
                         Text("Cancel")
                     }
                 }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/preview/ChordPreviewScreen.kt
@@ -85,7 +85,7 @@ fun ChordPreviewScreen(
             ) {
                 Button(
                     onClick = onBegin,
-                    modifier = Modifier.align(Alignment.CenterEnd)
+                    modifier = Modifier.fillMaxWidth()
                 ) {
                     Text("Begin  →")
                 }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeScreen.kt
@@ -120,7 +120,8 @@ fun StrumPracticeScreen(
                 ) {
                     StrumNote.entries.forEach { note ->
                         OutlinedButton(
-                            onClick = { viewModel.onNoteTypeChanged(note) }
+                            onClick = { viewModel.onNoteTypeChanged(note) },
+                            modifier = Modifier.fillMaxWidth()
                         ) {
                             StrumNoteSymbol(noteType = note)
                         }
@@ -151,7 +152,8 @@ fun StrumPracticeScreen(
                 ) {
                     // Save button (always first)
                     OutlinedButton(
-                        onClick = { viewModel.showSaveDialog() }
+                        onClick = { viewModel.showSaveDialog() },
+                        modifier = Modifier.fillMaxWidth()
                     ) {
                         Text("Save")
                     }
@@ -159,10 +161,12 @@ fun StrumPracticeScreen(
                     uiState.savedPatterns.forEach { pattern ->
                         OutlinedButton(
                             onClick = { /* disabled - handled by combinedClickable */ },
-                            modifier = Modifier.combinedClickable(
-                                onClick = { viewModel.loadPattern(pattern) },
-                                onLongClick = { viewModel.requestDeletePattern(pattern) }
-                            )
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .combinedClickable(
+                                    onClick = { viewModel.loadPattern(pattern) },
+                                    onLongClick = { viewModel.requestDeletePattern(pattern) }
+                                )
                         ) {
                             Text(pattern.toName())
                         }
@@ -209,10 +213,16 @@ fun StrumPracticeScreen(
                 Text("A pattern named \"${uiState.replacePatternName}\" already exists. Replace it?")
             },
             confirmButton = {
-                Button(onClick = { viewModel.confirmReplacePattern() }) { Text("Yes") }
+                Button(
+                    onClick = { viewModel.confirmReplacePattern() },
+                    modifier = Modifier.fillMaxWidth()
+                ) { Text("Yes") }
             },
             dismissButton = {
-                TextButton(onClick = { viewModel.cancelReplacePattern() }) { Text("No") }
+                TextButton(
+                    onClick = { viewModel.cancelReplacePattern() },
+                    modifier = Modifier.fillMaxWidth()
+                ) { Text("No") }
             }
         )
     }
@@ -223,10 +233,16 @@ fun StrumPracticeScreen(
             onDismissRequest = { viewModel.cancelDeletePattern() },
             title = { Text("Delete pattern ${pattern.toName()}?") },
             confirmButton = {
-                Button(onClick = { viewModel.confirmDeletePattern() }) { Text("Delete") }
+                Button(
+                    onClick = { viewModel.confirmDeletePattern() },
+                    modifier = Modifier.fillMaxWidth()
+                ) { Text("Delete") }
             },
             dismissButton = {
-                TextButton(onClick = { viewModel.cancelDeletePattern() }) { Text("Cancel") }
+                TextButton(
+                    onClick = { viewModel.cancelDeletePattern() },
+                    modifier = Modifier.fillMaxWidth()
+                ) { Text("Cancel") }
             }
         )
     }
@@ -358,10 +374,17 @@ private fun SavePatternDialog(
             )
         },
         confirmButton = {
-            Button(onClick = { onSave(name) }, enabled = name.isNotBlank()) { Text("Save") }
+            Button(
+                onClick = { onSave(name) },
+                enabled = name.isNotBlank(),
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Save") }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Cancel") }
         }
     )
 }


### PR DESCRIPTION
## Summary
- Added `fillMaxWidth()` to all `Button`, `OutlinedButton`, and `TextButton` instances that were missing it across the app
- Affected screens: `InstrumentSelectionScreen`, `ChordLibraryScreen`, `ChordPreviewScreen`, `StrumPracticeScreen`
- Includes main screen buttons, filter/selector buttons, and dialog confirm/dismiss buttons

## Test plan
- [ ] Instrument selection screen: Chord Quiz / Note Quiz / Strum Practice / Tuner selector buttons span full width
- [ ] Chord library screen: delete confirmation dialog buttons span full width
- [ ] Chord preview screen: "Begin" button spans full width
- [ ] Strum practice screen: note type selector buttons, Save button, saved pattern buttons span full width
- [ ] Strum practice dialogs (save, replace, delete): confirm/dismiss buttons span full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)