### PR TITLE
Remove unused showChordName parameter from ChordDiagram

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -32,8 +32,7 @@ import com.chordquiz.app.ui.theme.NutBrown
 fun ChordDiagram(
     chord: ChordDefinition,
     modifier: Modifier = Modifier,
-    fingeringIndex: Int = 0,
-    showChordName: Boolean = false
+    fingeringIndex: Int = 0
 ) {
     val fingering = chord.fingerings.getOrElse(fingeringIndex) { chord.fingerings.first() }
     ChordDiagramCanvas(


### PR DESCRIPTION
## Summary
Removes the unused `showChordName: Boolean = false` parameter from the `ChordDiagram` composable function.

## Changes
- Removed the dead parameter from the function signature in `ChordDiagram.kt`
- Verified no call sites pass this parameter (all rely on the default value)
- Confirmed no other references to `showChordName` exist in the codebase

## Why
Dead parameters create confusion in the API ("does this actually do something?") and accumulate as maintenance burden. This parameter was never used in the function body and no call sites ever passed it.

Fixes #143