### PR TITLE
Centralize audio threshold constants into AudioConstants

### DIFF
--- a/app/src/main/java/com/chordquiz/app/audio/AudioConstants.kt
+++ b/app/src/main/java/com/chordquiz/app/audio/AudioConstants.kt
@@ -1,0 +1,14 @@
+package com.chordquiz.app.audio
+
+/**
+ * Centralized audio processing thresholds and constants.
+ * Single source of truth for tuning values used across chord recognition and pitch detection.
+ */
+object AudioConstants {
+
+    /** RMS amplitude below which audio is treated as silence. */
+    const val SILENCE_THRESHOLD = 0.02f
+
+    /** Minimum chroma vector similarity to accept a chord match. */
+    const val CHROMA_THRESHOLD = 0.15
+}

--- a/app/src/main/java/com/chordquiz/app/audio/ChordRecognizer.kt
+++ b/app/src/main/java/com/chordquiz/app/audio/ChordRecognizer.kt
@@ -28,7 +28,6 @@ class ChordRecognizer @Inject constructor() {
 
     companion object {
         private const val WINDOW_SIZE = 4
-        private const val CHROMA_THRESHOLD = 0.15
         private const val MIN_CONFIDENCE = 0.4f
     }
 
@@ -90,7 +89,7 @@ class ChordRecognizer @Inject constructor() {
 
         // Detected note set: chroma bins whose normalized energy exceeds the threshold
         val detectedNotes = Note.entries
-            .filter { chroma[it.semitone] >= CHROMA_THRESHOLD }
+            .filter { chroma[it.semitone] >= AudioConstants.CHROMA_THRESHOLD }
             .toSet()
 
         // Early termination: find the best match with early termination

--- a/app/src/main/java/com/chordquiz/app/audio/TunerPitchDetector.kt
+++ b/app/src/main/java/com/chordquiz/app/audio/TunerPitchDetector.kt
@@ -9,7 +9,6 @@ package com.chordquiz.app.audio
  */
 object TunerPitchDetector {
 
-    private const val SILENCE_THRESHOLD = 0.02f
     private const val YIN_THRESHOLD = 0.15f
     private const val YIN_FALLBACK_THRESHOLD = 0.35
 
@@ -28,7 +27,7 @@ object TunerPitchDetector {
         samples: ShortArray,
         sampleRate: Int = AudioRecorderManager.SAMPLE_RATE
     ): Float? {
-        if (PitchDetector.computeAmplitude(samples) < SILENCE_THRESHOLD) return null
+        if (PitchDetector.computeAmplitude(samples) < AudioConstants.SILENCE_THRESHOLD) return null
 
         // Clamp buffer to 4096 samples for consistent performance
         val n = minOf(samples.size, 4096)

--- a/app/src/main/java/com/chordquiz/app/domain/EvaluateAudioAnswerUseCase.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/EvaluateAudioAnswerUseCase.kt
@@ -1,5 +1,6 @@
 package com.chordquiz.app.domain
 
+import com.chordquiz.app.audio.AudioConstants
 import com.chordquiz.app.data.model.ChordDefinition
 import com.chordquiz.app.data.model.Note
 import com.chordquiz.app.domain.model.Difficulty
@@ -11,7 +12,7 @@ class EvaluateAudioAnswerUseCase @Inject constructor() {
      * Minimum normalized RMS amplitude required for audio to be processed.
      * Initialized to a safe default; updated by [calibrateNoise] at recorder start.
      */
-    var dynamicSilenceThreshold: Float = 0.02f
+    var dynamicSilenceThreshold: Float = AudioConstants.SILENCE_THRESHOLD
         private set
 
     /**


### PR DESCRIPTION
## Summary

Fixes #145 by consolidating magic numbers used as audio thresholds into a centralized `AudioConstants` object.

## Changes

- Created `app/src/main/java/com/chordquiz/app/audio/AudioConstants.kt` with:
  - `SILENCE_THRESHOLD = 0.02f` - RMS amplitude silence gate
  - `CHROMA_THRESHOLD = 0.15` - Minimum chroma vector similarity for chord matches

- Updated three files to use the new constants:
  - `EvaluateAudioAnswerUseCase.kt` - line 15
  - `TunerPitchDetector.kt` - removed private constant, now uses AudioConstants
  - `ChordRecognizer.kt` - removed private constant, now uses AudioConstants

## Benefits

- Single source of truth for audio thresholds
- Documented purpose of each threshold via named constants
- Easier maintenance — tuning values only need to be changed in one place
- No functional changes — this is pure refactoring for maintainability