### PR TITLE
Extract shared buildQuestionList helper (Issue #148)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/domain/BuildNoteQuizSessionUseCase.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/BuildNoteQuizSessionUseCase.kt
@@ -39,29 +39,13 @@ class BuildNoteQuizSessionUseCase @Inject constructor() {
     ): QuizSession {
         val pool = buildNotePool(instrument)
 
-        val shuffled = pool.shuffled()
-        val questions = if (shuffled.size >= questionCount) {
-            shuffled.take(questionCount).map { entry ->
-                QuizQuestion.NoteQuestion(
-                    note = entry.note,
-                    octave = entry.octave,
-                    displayName = entry.displayName,
-                    noteMode = noteMode
-                )
-            }
-        } else {
-            val repeated = mutableListOf<PoolEntry>()
-            while (repeated.size < questionCount) {
-                repeated.addAll(shuffled.shuffled())
-            }
-            repeated.take(questionCount).map { entry ->
-                QuizQuestion.NoteQuestion(
-                    note = entry.note,
-                    octave = entry.octave,
-                    displayName = entry.displayName,
-                    noteMode = noteMode
-                )
-            }
+        val questions = buildQuestionList(pool, questionCount).map { entry ->
+            QuizQuestion.NoteQuestion(
+                note = entry.note,
+                octave = entry.octave,
+                displayName = entry.displayName,
+                noteMode = noteMode
+            )
         }
 
         return QuizSession(

--- a/app/src/main/java/com/chordquiz/app/domain/BuildQuizSessionUseCase.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/BuildQuizSessionUseCase.kt
@@ -16,17 +16,8 @@ class BuildQuizSessionUseCase @Inject constructor() {
         questionCount: Int,
         repeatMissed: Boolean
     ): QuizSession {
-        val shuffled = selectedChords.shuffled()
-        val questions = if (shuffled.size >= questionCount) {
-            shuffled.take(questionCount).map { QuizQuestion.ChordQuestion(it) }
-        } else {
-            // Repeat chords to fill question count
-            val repeated = mutableListOf<ChordDefinition>()
-            while (repeated.size < questionCount) {
-                repeated.addAll(shuffled.shuffled())
-            }
-            repeated.take(questionCount).map { QuizQuestion.ChordQuestion(it) }
-        }
+        val questions = buildQuestionList(selectedChords, questionCount)
+            .map { QuizQuestion.ChordQuestion(it) }
         return QuizSession(
             id = UUID.randomUUID().toString(),
             mode = mode,

--- a/app/src/main/java/com/chordquiz/app/domain/QuizListBuilder.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/QuizListBuilder.kt
@@ -1,0 +1,14 @@
+package com.chordquiz.app.domain
+
+/**
+ * Returns exactly [count] items drawn from [candidates] by shuffling and
+ * repeating the list as many times as needed.
+ */
+fun <T> buildQuestionList(candidates: List<T>, count: Int): List<T> {
+    require(candidates.isNotEmpty()) { "candidates must not be empty" }
+    val shuffled = candidates.shuffled()
+    return generateSequence { shuffled }
+        .flatten()
+        .take(count)
+        .toList()
+}


### PR DESCRIPTION
## Summary

Extracts duplicated shuffle-and-repeat logic from `BuildQuizSessionUseCase` and `BuildNoteQuizSessionUseCase` into a shared, generic `buildQuestionList` helper function.

## Changes

- **Created** `QuizListBuilder.kt` with `buildQuestionList<T>(candidates: List<T>, count: Int): List<T>`
  - Uses `generateSequence` with `flatten()` to infinitely repeat the shuffled list
  - Includes validation with `require(candidates.isNotEmpty())`
  - Handles both small and large candidate lists efficiently

- **Updated** `BuildQuizSessionUseCase` to use the helper
  - Removed 11 lines of manual shuffle-and-repeat logic
  - Cleaner, more maintainable code

- **Updated** `BuildNoteQuizSessionUseCase` to use the helper
  - Removed ~24 lines of duplicate shuffle-and-repeat logic

## Benefits

- **Single Source of Truth**: One shared implementation reduces risk of subtle bugs
- **Better Maintainability**: Changes to shuffle logic only need to be made in one place
- **Code Reduction**: Net reduction of 11 lines by eliminating duplication
- **Type Safe**: Generic implementation works with any list type

## Testing

The helper function can be tested with:
- Small candidate lists (fewer items than required questions)
- Exact-size candidate lists (equal items to questions)
- Large candidate lists (more items than required questions)
- Edge cases (single item, many repetitions required)