### PR TITLE
Extract drawMutedX and drawOpenCircle extensions (issue #149)

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/ChordDiagram.kt
@@ -145,16 +145,10 @@ fun ChordDiagramCanvas(
             val x = effectiveLeftPad + pos.stringIndex * stringSpacing
             when {
                 pos.fret == -1 -> {
-                    // Muted X
-                    drawLine(mutedColor, Offset(x - symbolRadius, symbolY - symbolRadius),
-                        Offset(x + symbolRadius, symbolY + symbolRadius), 2f)
-                    drawLine(mutedColor, Offset(x + symbolRadius, symbolY - symbolRadius),
-                        Offset(x - symbolRadius, symbolY + symbolRadius), 2f)
+                    drawMutedX(Offset(x, symbolY), symbolRadius, mutedColor)
                 }
                 pos.fret == 0 -> {
-                    // Open circle
-                    drawCircle(effectiveOpenColor, symbolRadius, Offset(x, symbolY), style =
-                        androidx.compose.ui.graphics.drawscope.Stroke(width = 2f))
+                    drawOpenCircle(Offset(x, symbolY), symbolRadius, effectiveOpenColor)
                 }
             }
         }

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/DrawScopeExtensions.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/DrawScopeExtensions.kt
@@ -1,0 +1,15 @@
+package com.chordquiz.app.ui.components.chord
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+
+fun DrawScope.drawMutedX(center: Offset, radius: Float, color: Color, strokeWidth: Float = 2f) {
+    drawLine(color, Offset(center.x - radius, center.y - radius), Offset(center.x + radius, center.y + radius), strokeWidth)
+    drawLine(color, Offset(center.x + radius, center.y - radius), Offset(center.x - radius, center.y + radius), strokeWidth)
+}
+
+fun DrawScope.drawOpenCircle(center: Offset, radius: Float, color: Color, strokeWidth: Float = 2f) {
+    drawCircle(color, radius, center, style = Stroke(strokeWidth))
+}

--- a/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/chord/InteractiveChordDiagram.kt
@@ -537,8 +537,7 @@ private fun FretItem(
                     when (pos.fret) {
                         -1 -> {
                             val col = if (pos.stringIndex in incorrectMutedStrings) IncorrectRed else MutedGray
-                            drawLine(col, Offset(x - dotRadius, midY - dotRadius), Offset(x + dotRadius, midY + dotRadius), 2f)
-                            drawLine(col, Offset(x + dotRadius, midY - dotRadius), Offset(x - dotRadius, midY + dotRadius), 2f)
+                            drawMutedX(Offset(x, midY), dotRadius, col)
                         }
                         0 -> {
                             val col = if (pos.stringIndex in missedMuteStrings || pos.stringIndex in incorrectFrettedStrings)
@@ -560,7 +559,7 @@ private fun FretItem(
                                     style = labelStyle
                                 )
                             } else {
-                                drawCircle(col, dotRadius, Offset(x, midY), style = Stroke(2f))
+                                drawOpenCircle(Offset(x, midY), dotRadius, col)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
Resolves #149 by extracting chord symbol drawing logic into reusable extension functions.

## Changes
- **New file**: `DrawScopeExtensions.kt` with two extension functions:
  - `drawMutedX()` - Draws muted-string X symbol
  - `drawOpenCircle()` - Draws open-string circle symbol
- **Updated**: `ChordDiagram.kt` to use the new extensions
- **Updated**: `InteractiveChordDiagram.kt` to use the new extensions

## Benefits
- Eliminates code duplication (8 lines of identical drawing code)
- Centralizes symbol drawing logic for easier maintenance
- Makes drawing intent clear at call sites
- Prevents accidental inconsistencies in symbol rendering

## Testing
- All chord symbols render correctly in both static and interactive diagrams
- Muted strings display X symbols
- Open strings display circle symbols
- Interactive diagram note labels still display when enabled
- Colors apply correctly (muted gray for static, conditional for interactive)