### PR TITLE
Extract semitoneToDiatonic to domain layer for reusability

### DIFF
--- a/app/src/main/java/com/chordquiz/app/domain/MusicTheoryUtils.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/MusicTheoryUtils.kt
@@ -1,0 +1,16 @@
+package com.chordquiz.app.domain
+
+/**
+ * Maps a chromatic semitone (0 = C, 1 = C#, …, 11 = B) to its diatonic
+ * staff position (0 = C, 1 = D, 2 = E, 3 = F, 4 = G, 5 = A, 6 = B).
+ */
+fun semitoneToDiatonic(semitone: Int): Int = when (semitone % 12) {
+    0, 1  -> 0   // C, C#
+    2     -> 1   // D
+    3, 4  -> 2   // Eb/D#, E
+    5, 6  -> 3   // F, F#
+    7, 8  -> 4   // G, G#
+    9, 10 -> 5   // A, Bb
+    11    -> 6   // B
+    else  -> 0
+}

--- a/app/src/main/java/com/chordquiz/app/ui/components/staff/MusicStaff.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/staff/MusicStaff.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
+import com.chordquiz.app.domain.semitoneToDiatonic
 
 data class StaffNote(val semitone: Int, val octave: Int, val displayName: String)
 
@@ -155,28 +156,6 @@ private fun noteToStaffStep(semitone: Int, octave: Int, clef: Clef): Int {
     val absoluteStep = octave * 7 + diatonicStep
     // Middle C (C4) is at absolute step = 4*7 + 0 = 28
     return absoluteStep - 28
-}
-
-/**
- * Converts semitone (0=C) to diatonic step (0=C, 1=D, 2=E, 3=F, 4=G, 5=A, 6=B).
- * For accidentals (sharps/flats), rounds to nearest diatonic note.
- */
-private fun semitoneToDiatonic(semitone: Int): Int {
-    return when (semitone % 12) {
-        0 -> 0   // C
-        1 -> 0   // C#/Db → use C position (accidental drawn separately)
-        2 -> 1   // D
-        3 -> 2   // D#/Eb → use E position
-        4 -> 2   // E
-        5 -> 3   // F
-        6 -> 3   // F#/Gb → use F position
-        7 -> 4   // G
-        8 -> 4   // G#/Ab → use G position
-        9 -> 5   // A
-        10 -> 5  // A#/Bb → use A position
-        11 -> 6  // B
-        else -> 0
-    }
 }
 
 /**

--- a/app/src/main/java/com/chordquiz/app/ui/components/staff/MusicalGradeStaff.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/staff/MusicalGradeStaff.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import com.chordquiz.app.audio.NotePlayer
+import com.chordquiz.app.domain.semitoneToDiatonic
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 
@@ -48,21 +49,6 @@ private val NOTE_COLORS: List<Color> = run {
     (0..8).map { i ->
         if (i <= 4) lerp(red, yellow, i / 4f) else lerp(yellow, green, (i - 4) / 4f)
     }
-}
-
-/**
- * Converts a semitone value (0 = C) to a diatonic step within the octave (0 = C … 6 = B).
- * Accidentals are mapped to the nearest diatonic position (same logic as MusicStaff.kt).
- */
-private fun semitoneToDiatonic(semitone: Int): Int = when (semitone % 12) {
-    0, 1  -> 0   // C, C#
-    2     -> 1   // D
-    3, 4  -> 2   // Eb/D#, E
-    5, 6  -> 3   // F, F#
-    7, 8  -> 4   // G, G#
-    9, 10 -> 5   // A, Bb
-    11    -> 6   // B
-    else  -> 0
 }
 
 /**


### PR DESCRIPTION
## Summary
Refactored the `semitoneToDiatonic` utility function from UI components into the domain layer to promote code reuse and better separation of concerns.

## Key Changes
- Created new `MusicTheoryUtils.kt` in the domain package with the `semitoneToDiatonic` function
- Removed duplicate `semitoneToDiatonic` implementations from `MusicStaff.kt` and `MusicalGradeStaff.kt`
- Updated both UI components to import the function from the domain layer
- Consolidated the function logic to a single, authoritative implementation

## Implementation Details
- The function maps chromatic semitones (0-11, where 0=C) to diatonic staff positions (0-6, where 0=C through 6=B)
- Accidentals are mapped to their nearest diatonic position for staff rendering
- The domain-level implementation uses a more concise `when` expression with grouped cases for better readability

https://claude.ai/code/session_01BGe9xq8Fd7RhAgvYnaPa1i