### PR TITLE
Extract practice setup UI into reusable component

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/PracticeSetupContent.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/PracticeSetupContent.kt
@@ -1,0 +1,172 @@
+package com.chordquiz.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.RemoveCircle
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.chordquiz.app.data.model.QuizMode
+
+@Composable
+fun PracticeSetupContent(
+    headerText: @Composable () -> Unit,
+    drawModeTitle: String = "Draw",
+    drawModeDescription: String,
+    playModeTitle: String = "Play",
+    playModeDescription: String,
+    repeatMissedLabel: String,
+    repeatMissedDescription: String,
+    currentMode: QuizMode,
+    onModeChanged: (QuizMode) -> Unit,
+    questionCount: Int,
+    onIncrementQuestionCount: () -> Unit,
+    onDecrementQuestionCount: () -> Unit,
+    repeatMissed: Boolean,
+    onRepeatMissedChanged: (Boolean) -> Unit,
+    onStartQuiz: () -> Unit,
+    drawModeValue: QuizMode,
+    playModeValue: QuizMode
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        headerText()
+
+        // Quiz Mode
+        Text("QUIZ MODE", style = MaterialTheme.typography.labelLarge)
+
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = if (currentMode == drawModeValue)
+                    MaterialTheme.colorScheme.primaryContainer
+                else MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(Icons.Default.Edit, contentDescription = null)
+                Spacer(Modifier.width(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(drawModeTitle, style = MaterialTheme.typography.titleSmall)
+                    Text(drawModeDescription,
+                        style = MaterialTheme.typography.bodySmall)
+                }
+                RadioButton(
+                    selected = currentMode == drawModeValue,
+                    onClick = { onModeChanged(drawModeValue) }
+                )
+            }
+        }
+
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = if (currentMode == playModeValue)
+                    MaterialTheme.colorScheme.primaryContainer
+                else MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(Icons.Default.MusicNote, contentDescription = null)
+                Spacer(Modifier.width(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(playModeTitle, style = MaterialTheme.typography.titleSmall)
+                    Text(playModeDescription,
+                        style = MaterialTheme.typography.bodySmall)
+                }
+                RadioButton(
+                    selected = currentMode == playModeValue,
+                    onClick = { onModeChanged(playModeValue) }
+                )
+            }
+        }
+
+        HorizontalDivider()
+
+        // Question count
+        Text("NUMBER OF QUESTIONS", style = MaterialTheme.typography.labelLarge)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onDecrementQuestionCount) {
+                Icon(Icons.Default.RemoveCircle, "Decrease")
+            }
+            Text(
+                questionCount.toString(),
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+            IconButton(onClick = onIncrementQuestionCount) {
+                Icon(Icons.Default.AddCircle, "Increase")
+            }
+        }
+
+        HorizontalDivider()
+
+        // Repeat missed
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(repeatMissedLabel, style = MaterialTheme.typography.titleSmall)
+                Text(repeatMissedDescription,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Switch(
+                checked = repeatMissed,
+                onCheckedChange = { onRepeatMissedChanged(it) }
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        Button(
+            onClick = onStartQuiz,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Start Quiz  →")
+        }
+    }
+}

--- a/app/src/main/java/com/chordquiz/app/ui/screen/setup/NotePracticeSetupScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/setup/NotePracticeSetupScreen.kt
@@ -1,5 +1,8 @@
 package com.chordquiz.app.ui.screen.setup
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -10,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -44,14 +48,14 @@ fun NotePracticeSetupScreen(
             )
         }
     ) { innerPadding ->
-        androidx.compose.foundation.layout.Box(
-            modifier = androidx.compose.ui.Modifier
+        Box(
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
             PracticeSetupContent(
                 headerText = {
-                    androidx.compose.material3.Text(
+                    Text(
                         buildAnnotatedString {
                             withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
                                 append(noteMode.displayName)

--- a/app/src/main/java/com/chordquiz/app/ui/screen/setup/NotePracticeSetupScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/setup/NotePracticeSetupScreen.kt
@@ -1,48 +1,24 @@
 package com.chordquiz.app.ui.screen.setup
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AddCircle
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.MusicNote
-import androidx.compose.material.icons.filled.RemoveCircle
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chordquiz.app.data.model.NoteMode
 import com.chordquiz.app.data.model.QuizMode
+import com.chordquiz.app.ui.components.PracticeSetupContent
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,134 +44,36 @@ fun NotePracticeSetupScreen(
             )
         }
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
+        androidx.compose.foundation.layout.Box(
+            modifier = androidx.compose.ui.Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(16.dp)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text(
-                buildAnnotatedString {
-                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                        append(noteMode.displayName)
-                    }
-                    append(" selected")
+            PracticeSetupContent(
+                headerText = {
+                    androidx.compose.material3.Text(
+                        buildAnnotatedString {
+                            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                                append(noteMode.displayName)
+                            }
+                            append(" selected")
+                        },
+                        style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 },
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            // Quiz Mode
-            Text("QUIZ MODE", style = MaterialTheme.typography.labelLarge)
-
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = if (uiState.mode == QuizMode.NOTE_DRAW)
-                        MaterialTheme.colorScheme.primaryContainer
-                    else MaterialTheme.colorScheme.surfaceVariant
-                )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(Icons.Default.Edit, contentDescription = null)
-                    Spacer(Modifier.width(12.dp))
-                    Column(Modifier.weight(1f)) {
-                        Text("Draw", style = MaterialTheme.typography.titleSmall)
-                        Text(
-                            "Place finger dots on the notes",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                    RadioButton(
-                        selected = uiState.mode == QuizMode.NOTE_DRAW,
-                        onClick = { viewModel.setMode(QuizMode.NOTE_DRAW) }
-                    )
-                }
-            }
-
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = if (uiState.mode == QuizMode.NOTE_PLAY)
-                        MaterialTheme.colorScheme.primaryContainer
-                    else MaterialTheme.colorScheme.surfaceVariant
-                )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(Icons.Default.MusicNote, contentDescription = null)
-                    Spacer(Modifier.width(12.dp))
-                    Column(Modifier.weight(1f)) {
-                        Text("Play", style = MaterialTheme.typography.titleSmall)
-                        Text(
-                            "Pluck your instrument, we'll detect the note",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                    RadioButton(
-                        selected = uiState.mode == QuizMode.NOTE_PLAY,
-                        onClick = { viewModel.setMode(QuizMode.NOTE_PLAY) }
-                    )
-                }
-            }
-
-            HorizontalDivider()
-
-            // Question count
-            Text("NUMBER OF QUESTIONS", style = MaterialTheme.typography.labelLarge)
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                IconButton(onClick = { viewModel.decrementQuestionCount() }) {
-                    Icon(Icons.Default.RemoveCircle, "Decrease")
-                }
-                Text(
-                    uiState.questionCount.toString(),
-                    style = MaterialTheme.typography.headlineMedium,
-                    modifier = Modifier.padding(horizontal = 24.dp)
-                )
-                IconButton(onClick = { viewModel.incrementQuestionCount() }) {
-                    Icon(Icons.Default.AddCircle, "Increase")
-                }
-            }
-
-            HorizontalDivider()
-
-            // Repeat missed
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column {
-                    Text("Repeat missed notes", style = MaterialTheme.typography.titleSmall)
-                    Text(
-                        "Replay incorrectly answered notes",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Switch(
-                    checked = uiState.repeatMissed,
-                    onCheckedChange = { viewModel.setRepeatMissed(it) }
-                )
-            }
-
-            Spacer(Modifier.height(8.dp))
-
-            Button(
-                onClick = {
+                drawModeDescription = "Place finger dots on the notes",
+                playModeDescription = "Pluck your instrument, we'll detect the note",
+                repeatMissedLabel = "Repeat missed notes",
+                repeatMissedDescription = "Replay incorrectly answered notes",
+                currentMode = uiState.mode,
+                onModeChanged = { viewModel.setMode(it) },
+                questionCount = uiState.questionCount,
+                onIncrementQuestionCount = { viewModel.incrementQuestionCount() },
+                onDecrementQuestionCount = { viewModel.decrementQuestionCount() },
+                repeatMissed = uiState.repeatMissed,
+                onRepeatMissedChanged = { viewModel.setRepeatMissed(it) },
+                onStartQuiz = {
                     if (uiState.mode == QuizMode.NOTE_DRAW) {
                         onStartDrawQuiz(instrumentId, noteMode,
                             uiState.questionCount, uiState.repeatMissed)
@@ -204,10 +82,9 @@ fun NotePracticeSetupScreen(
                             uiState.questionCount, uiState.repeatMissed)
                     }
                 },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Start Quiz  →")
-            }
+                drawModeValue = QuizMode.NOTE_DRAW,
+                playModeValue = QuizMode.NOTE_PLAY
+            )
         }
     }
 }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/setup/PracticeSetupScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/setup/PracticeSetupScreen.kt
@@ -1,43 +1,19 @@
 package com.chordquiz.app.ui.screen.setup
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AddCircle
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.MusicNote
-import androidx.compose.material.icons.filled.RemoveCircle
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chordquiz.app.data.model.QuizMode
+import com.chordquiz.app.ui.components.PracticeSetupContent
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,123 +39,31 @@ fun PracticeSetupScreen(
             )
         }
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
+        androidx.compose.foundation.layout.Box(
+            modifier = androidx.compose.ui.Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(16.dp)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text(
-                "${selectedChordIds.size} chords selected",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            // Quiz Mode
-            Text("QUIZ MODE", style = MaterialTheme.typography.labelLarge)
-
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = if (uiState.mode == QuizMode.DRAW)
-                        MaterialTheme.colorScheme.primaryContainer
-                    else MaterialTheme.colorScheme.surfaceVariant
-                )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(Icons.Default.Edit, contentDescription = null)
-                    Spacer(Modifier.width(12.dp))
-                    Column(Modifier.weight(1f)) {
-                        Text("Draw", style = MaterialTheme.typography.titleSmall)
-                        Text("Place finger dots on a blank diagram",
-                            style = MaterialTheme.typography.bodySmall)
-                    }
-                    RadioButton(
-                        selected = uiState.mode == QuizMode.DRAW,
-                        onClick = { viewModel.setMode(QuizMode.DRAW) }
+            PracticeSetupContent(
+                headerText = {
+                    androidx.compose.material3.Text(
+                        "${selectedChordIds.size} chords selected",
+                        style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                }
-            }
-
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = if (uiState.mode == QuizMode.PLAY)
-                        MaterialTheme.colorScheme.primaryContainer
-                    else MaterialTheme.colorScheme.surfaceVariant
-                )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(Icons.Default.MusicNote, contentDescription = null)
-                    Spacer(Modifier.width(12.dp))
-                    Column(Modifier.weight(1f)) {
-                        Text("Play", style = MaterialTheme.typography.titleSmall)
-                        Text("Strum your instrument, we'll detect the chord",
-                            style = MaterialTheme.typography.bodySmall)
-                    }
-                    RadioButton(
-                        selected = uiState.mode == QuizMode.PLAY,
-                        onClick = { viewModel.setMode(QuizMode.PLAY) }
-                    )
-                }
-            }
-
-            HorizontalDivider()
-
-            // Question count
-            Text("NUMBER OF QUESTIONS", style = MaterialTheme.typography.labelLarge)
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                IconButton(onClick = { viewModel.decrementQuestionCount() }) {
-                    Icon(Icons.Default.RemoveCircle, "Decrease")
-                }
-                Text(
-                    uiState.questionCount.toString(),
-                    style = MaterialTheme.typography.headlineMedium,
-                    modifier = Modifier.padding(horizontal = 24.dp)
-                )
-                IconButton(onClick = { viewModel.incrementQuestionCount() }) {
-                    Icon(Icons.Default.AddCircle, "Increase")
-                }
-            }
-
-            HorizontalDivider()
-
-            // Repeat missed
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column {
-                    Text("Repeat missed chords", style = MaterialTheme.typography.titleSmall)
-                    Text("Replay incorrectly answered chords",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-                Switch(
-                    checked = uiState.repeatMissed,
-                    onCheckedChange = { viewModel.setRepeatMissed(it) }
-                )
-            }
-
-            Spacer(Modifier.height(8.dp))
-
-            Button(
-                onClick = {
+                },
+                drawModeDescription = "Place finger dots on a blank diagram",
+                playModeDescription = "Strum your instrument, we'll detect the chord",
+                repeatMissedLabel = "Repeat missed chords",
+                repeatMissedDescription = "Replay incorrectly answered chords",
+                currentMode = uiState.mode,
+                onModeChanged = { viewModel.setMode(it) },
+                questionCount = uiState.questionCount,
+                onIncrementQuestionCount = { viewModel.incrementQuestionCount() },
+                onDecrementQuestionCount = { viewModel.decrementQuestionCount() },
+                repeatMissed = uiState.repeatMissed,
+                onRepeatMissedChanged = { viewModel.setRepeatMissed(it) },
+                onStartQuiz = {
                     if (uiState.mode == QuizMode.DRAW) {
                         onStartDrawQuiz(instrumentId, selectedChordIds,
                             uiState.questionCount, uiState.repeatMissed)
@@ -188,10 +72,9 @@ fun PracticeSetupScreen(
                             uiState.questionCount, uiState.repeatMissed)
                     }
                 },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Start Quiz  →")
-            }
+                drawModeValue = QuizMode.DRAW,
+                playModeValue = QuizMode.PLAY
+            )
         }
     }
 }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/setup/PracticeSetupScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/setup/PracticeSetupScreen.kt
@@ -1,5 +1,8 @@
 package com.chordquiz.app.ui.screen.setup
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -10,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chordquiz.app.data.model.QuizMode
@@ -39,14 +43,14 @@ fun PracticeSetupScreen(
             )
         }
     ) { innerPadding ->
-        androidx.compose.foundation.layout.Box(
-            modifier = androidx.compose.ui.Modifier
+        Box(
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
             PracticeSetupContent(
                 headerText = {
-                    androidx.compose.material3.Text(
+                    Text(
                         "${selectedChordIds.size} chords selected",
                         style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
                         color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant


### PR DESCRIPTION
## Summary
Refactored the practice setup screens to eliminate code duplication by extracting the common UI layout into a reusable `PracticeSetupContent` composable component.

## Key Changes
- **Created new component**: `PracticeSetupContent.kt` - A parameterized composable that encapsulates the quiz mode selection, question count adjustment, repeat missed toggle, and start quiz button
- **Refactored `PracticeSetupScreen.kt`**: Replaced 123 lines of UI code with a single `PracticeSetupContent` call, passing mode-specific strings and callbacks
- **Refactored `NotePracticeSetupScreen.kt`**: Applied the same refactoring pattern, reducing duplicated layout code while maintaining note-specific behavior
- **Parameterized strings**: Made mode titles and descriptions configurable to support both chord and note quiz variants
- **Preserved functionality**: All state management and navigation logic remains in the respective screen ViewModels

## Implementation Details
The new `PracticeSetupContent` component accepts:
- A composable lambda for the header text (allowing custom content per screen)
- Mode-specific descriptions for Draw and Play modes
- Repeat missed label and description (customizable for chords vs notes)
- Callbacks for all user interactions (mode selection, question count changes, repeat missed toggle, quiz start)
- Quiz mode enum values to support different mode types across screens

This approach maintains separation of concerns while eliminating ~100 lines of duplicated UI code across the two setup screens.

https://claude.ai/code/session_013MebypA6QeJP6ViDvquuaL