### PR TITLE
Replace long-press gestures with explicit delete buttons

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryScreen.kt
@@ -4,10 +4,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -125,6 +121,16 @@ fun ChordLibraryScreen(
                             Text("Save")
                         }
                     }
+                    if (uiState.activeGroupFilter?.isCustom() == true) {
+                        OutlinedButton(
+                            onClick = {
+                                viewModel.requestDeleteGroup(uiState.activeGroupFilter!!)
+                            },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text("Delete?")
+                        }
+                    }
                     Button(
                         onClick = {
                             onStartPractice(instrumentId, uiState.selectedChordIds.toList())
@@ -200,23 +206,11 @@ fun ChordLibraryScreen(
                     }
                     uiState.customGroups.forEach { group ->
                         key(group.id) {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .pointerInput(group.id) {
-                                        detectTapGestures(
-                                            onLongPress = {
-                                                viewModel.requestDeleteGroup(group)
-                                            }
-                                        )
-                                    }
+                            OutlinedButton(
+                                onClick = { viewModel.setGroupFilter(group) },
+                                modifier = Modifier.fillMaxWidth()
                             ) {
-                                OutlinedButton(
-                                    onClick = { viewModel.setGroupFilter(group) },
-                                    modifier = Modifier.fillMaxWidth()
-                                ) {
-                                    Text(group.toName())
-                                }
+                                Text(group.toName())
                             }
                         }
                     }

--- a/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeScreen.kt
@@ -160,13 +160,8 @@ fun StrumPracticeScreen(
                     // Saved pattern buttons
                     uiState.savedPatterns.forEach { pattern ->
                         OutlinedButton(
-                            onClick = { /* disabled - handled by combinedClickable */ },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .combinedClickable(
-                                    onClick = { viewModel.loadPattern(pattern) },
-                                    onLongClick = { viewModel.requestDeletePattern(pattern) }
-                                )
+                            onClick = { viewModel.loadPattern(pattern) },
+                            modifier = Modifier.fillMaxWidth()
                         ) {
                             Text(pattern.toName())
                         }
@@ -174,8 +169,23 @@ fun StrumPracticeScreen(
                 }
             }
 
-            // ── Play / Stop button ───────────────────────────────────────────
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            // ── Delete and Play buttons ──────────────────────────────────────
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Center),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (uiState.selectedPatternId != null) {
+                    OutlinedButton(
+                        onClick = {
+                            uiState.savedPatterns.find { it.id == uiState.selectedPatternId }?.let {
+                                viewModel.requestDeletePattern(it)
+                            }
+                        }
+                    ) {
+                        Text("Delete?")
+                    }
+                }
                 FilledIconButton(
                     onClick = viewModel::togglePlay,
                     modifier = Modifier.size(64.dp)

--- a/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeScreen.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeScreen.kt
@@ -172,7 +172,7 @@ fun StrumPracticeScreen(
             // ── Delete and Play buttons ──────────────────────────────────────
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Center),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (uiState.selectedPatternId != null) {

--- a/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/strumpractice/StrumPracticeViewModel.kt
@@ -35,6 +35,7 @@ data class StrumPracticeUiState(
     val slots: List<StrumSlot> = defaultSlotsFor(StrumNote.EIGHTH),
     val activeSlotIndex: Int = -1,
     val savedPatterns: List<SavedPatternEntity> = emptyList(),
+    val selectedPatternId: Long? = null,
     val showSaveDialog: Boolean = false,
     val saveNameError: String? = null,
     val showReplaceDialog: Boolean = false,
@@ -177,7 +178,7 @@ class StrumPracticeViewModel @Inject constructor(
         val noteType = runCatching { StrumNote.valueOf(pattern.noteType) }.getOrNull() ?: return
         val slots = pattern.slotList().mapNotNull { runCatching { StrumSlot.valueOf(it) }.getOrNull() }
         if (slots.size != noteType.slotCount) return
-        _uiState.update { it.copy(noteType = noteType, slots = slots, bpm = pattern.bpm, activeSlotIndex = -1) }
+        _uiState.update { it.copy(noteType = noteType, slots = slots, bpm = pattern.bpm, activeSlotIndex = -1, selectedPatternId = pattern.id) }
         metronome.updateNoteType(noteType.slotCount, noteType.subdivisionsPerBeat)
         metronome.updateBpm(pattern.bpm)
     }


### PR DESCRIPTION
## Summary
This PR replaces implicit long-press gesture handling with explicit "Delete?" buttons in the UI, improving discoverability and making destructive actions more intentional.

## Key Changes

- **ChordLibraryScreen**: 
  - Removed `detectTapGestures` and related imports for long-press detection on custom chord groups
  - Added conditional "Delete?" button that appears when a custom group is actively filtered
  - Simplified custom group list items by removing the wrapper `Box` with pointer input handling

- **StrumPracticeScreen**:
  - Removed `combinedClickable` modifier that handled long-press deletion of saved patterns
  - Added explicit "Delete?" button in a new Row layout alongside the play button
  - Delete button only appears when a pattern is currently selected (`selectedPatternId != null`)
  - Improved layout with proper spacing and alignment for delete and play controls

- **StrumPracticeViewModel**:
  - Added `selectedPatternId` property to `StrumPracticeUiState` to track the currently loaded pattern
  - Updated `loadPattern()` to set `selectedPatternId` when a pattern is loaded

## Implementation Details
The changes follow a consistent pattern: instead of relying on hidden gestures (long-press), users now see a "Delete?" button that only appears in the relevant context (when a group/pattern is selected). This makes the delete functionality more discoverable and requires explicit user action rather than relying on gesture knowledge.

https://claude.ai/code/session_01X9Bd3dPHpN89wU1Z2ShFSU