### PR TITLE
Fix issue #169: Remove hardcoded MIN_CONFIDENCE from ChordRecognizer

### DIFF
--- a/app/src/main/java/com/chordquiz/app/audio/ChordRecognizer.kt
+++ b/app/src/main/java/com/chordquiz/app/audio/ChordRecognizer.kt
@@ -32,7 +32,6 @@ class ChordRecognizer @Inject constructor() {
 
     companion object {
         private const val WINDOW_SIZE = 4
-        private const val MIN_CONFIDENCE = 0.4f
     }
 
     /** Configure the recognizer with difficulty-specific settings. */
@@ -102,24 +101,20 @@ class ChordRecognizer @Inject constructor() {
             .filter { chroma[it.semitone] >= AudioConstants.CHROMA_THRESHOLD }
             .toSet()
 
-        // Early termination: find the best match with early termination
+        // Find the best matching chord
         var bestChord: ChordDefinition? = null
         var bestScore = 0f
         for (chord in candidateChords) {
             val score = computeScore(chroma, chord)
-            // Early termination: if we've already found a very high score, stop early
-            if (score >= MIN_CONFIDENCE && score > bestScore) {
+            if (score > bestScore) {
                 bestScore = score
                 bestChord = chord
                 // Early termination: if we have a perfect match, no need to continue
                 if (bestScore >= 0.95f) break
-            } else if (score > bestScore) {
-                bestScore = score
-                bestChord = chord
             }
         }
 
-        val matchId = if (bestScore >= MIN_CONFIDENCE) bestChord?.id else null
+        val matchId = bestChord?.id
         pushWindow(matchId)
 
         // Require consistent detection across all [windowSize] frames


### PR DESCRIPTION
## Summary

The `ChordRecognizer` had a hardcoded internal confidence gate (`MIN_CONFIDENCE = 0.4f`) that silently rejected chords scoring below 0.4 before the difficulty system could apply its own acceptance threshold.

This fix removes `MIN_CONFIDENCE` entirely, allowing the recognizer to push the best-matching chord into the rolling window regardless of its raw score. The difficulty-aware acceptance threshold in `PlayQuizViewModel.isAcceptedByDifficulty()` is now the sole gate for confidence validation.

## Changes

- Removed `MIN_CONFIDENCE` constant from `ChordRecognizer` companion object
- Simplified best chord tracking to work unconditionally on score comparison
- Removed `MIN_CONFIDENCE` guard when pushing `matchId` to window

## Test Plan

- [ ] Verify chords with confidence below 0.4 now reach the `isAcceptedByDifficulty()` check
- [ ] Verify Easy mode can now accept chords with lower confidence based on its `acceptanceThreshold`
- [ ] Verify Medium and Hard modes behavior remains unchanged (their thresholds are above 0.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)