### PR TITLE
Fix issue #170: Make extra-note penalty difficulty-aware

### DIFF
--- a/app/src/main/java/com/chordquiz/app/audio/ChordRecognizer.kt
+++ b/app/src/main/java/com/chordquiz/app/audio/ChordRecognizer.kt
@@ -30,6 +30,9 @@ class ChordRecognizer @Inject constructor() {
     /** Window size for chord consistency checking, configurable by difficulty */
     private var windowSize: Int = Difficulty.DEFAULT.windowSize
 
+    /** Extra penalty factor for non-chord energy, configurable by difficulty */
+    private var extraPenaltyFactor: Double = Difficulty.DEFAULT.extraPenaltyFactor
+
     companion object {
         private const val WINDOW_SIZE = 4
     }
@@ -37,6 +40,7 @@ class ChordRecognizer @Inject constructor() {
     /** Configure the recognizer with difficulty-specific settings. */
     fun configure(difficulty: Difficulty) {
         windowSize = difficulty.windowSize
+        extraPenaltyFactor = difficulty.extraPenaltyFactor
         resetBuffer()
     }
 
@@ -140,7 +144,7 @@ class ChordRecognizer @Inject constructor() {
      *
      * Early termination optimization: if the score is already low, we can early terminate.
      */
-    private fun computeScore(chroma: DoubleArray, chord: ChordDefinition): Float {
+    internal fun computeScore(chroma: DoubleArray, chord: ChordDefinition): Float {
         val target = getChordComponents(chord)
         if (target.isEmpty()) return 0f
 
@@ -155,7 +159,7 @@ class ChordRecognizer @Inject constructor() {
         val extraEnergy = chroma.indices
             .filter { it !in targetSemitones }
             .sumOf { chroma[it] }
-        val extraPenalty = (extraEnergy / 12.0 * 0.4).coerceAtMost(0.25)
+        val extraPenalty = (extraEnergy / 12.0 * extraPenaltyFactor).coerceAtMost(extraPenaltyFactor * 0.625)
 
         val fingeringBonus = if (matchesFingeringTemplate(chroma, chord)) 0.1 else 0.0
 

--- a/app/src/main/java/com/chordquiz/app/domain/model/Difficulty.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/model/Difficulty.kt
@@ -4,11 +4,12 @@ enum class Difficulty(
     val acceptanceThreshold: Float,
     val requiresRoot: Boolean,
     val requiresThird: Boolean,
-    val windowSize: Int
+    val windowSize: Int,
+    val extraPenaltyFactor: Double
 ) {
-    EASY(acceptanceThreshold = 0.50f, requiresRoot = false, requiresThird = false, windowSize = 2),
-    MEDIUM(acceptanceThreshold = 0.65f, requiresRoot = true, requiresThird = false, windowSize = 3),
-    HARD(acceptanceThreshold = 0.80f, requiresRoot = true, requiresThird = true, windowSize = 4);
+    EASY(acceptanceThreshold = 0.50f, requiresRoot = false, requiresThird = false, windowSize = 2, extraPenaltyFactor = 0.15),
+    MEDIUM(acceptanceThreshold = 0.65f, requiresRoot = true, requiresThird = false, windowSize = 3, extraPenaltyFactor = 0.30),
+    HARD(acceptanceThreshold = 0.80f, requiresRoot = true, requiresThird = true, windowSize = 4, extraPenaltyFactor = 0.40);
 
     companion object {
         val DEFAULT = EASY


### PR DESCRIPTION
## Summary
- Added `extraPenaltyFactor` property to `Difficulty` enum to scale non-chord energy penalty
- EASY: 0.15 (more forgiving for beginners who accidentally strum open strings)
- MEDIUM: 0.30
- HARD: 0.40 (maintains current strict behavior)
- Penalty cap scales proportionally (factor * 0.625) to maintain consistent ratio
- Made `computeScore` internal to enable unit testing

## Test plan
- [ ] Verify Easy mode accepts chords with some unintended open strings ringing
- [ ] Verify Hard mode still penalizes sloppy playing
- [ ] Add unit tests for `computeScore()` with different difficulty levels

🤖 Generated with [Claude Code](https://claude.ai/code)