### PR TITLE
Fix issue #171: Lower Easy acceptanceThreshold to 0.35

### DIFF
--- a/app/src/main/java/com/chordquiz/app/domain/model/Difficulty.kt
+++ b/app/src/main/java/com/chordquiz/app/domain/model/Difficulty.kt
@@ -1,14 +1,18 @@
 package com.chordquiz.app.domain.model
 
 enum class Difficulty(
+    /** Minimum chord recognition confidence score (0–1) required to accept a detected chord. */
     val acceptanceThreshold: Float,
     val requiresRoot: Boolean,
     val requiresThird: Boolean,
     val windowSize: Int,
     val extraPenaltyFactor: Double
 ) {
-    EASY(acceptanceThreshold = 0.50f, requiresRoot = false, requiresThird = false, windowSize = 2, extraPenaltyFactor = 0.15),
+    /** Forgiving: accepts rough chord shapes, no specific note requirements. */
+    EASY(acceptanceThreshold = 0.35f, requiresRoot = false, requiresThird = false, windowSize = 2, extraPenaltyFactor = 0.15),
+    /** Standard: requires root note to be present. */
     MEDIUM(acceptanceThreshold = 0.65f, requiresRoot = true, requiresThird = false, windowSize = 3, extraPenaltyFactor = 0.30),
+    /** Strict: requires root and third, high confidence. */
     HARD(acceptanceThreshold = 0.80f, requiresRoot = true, requiresThird = true, windowSize = 4, extraPenaltyFactor = 0.40);
 
     companion object {


### PR DESCRIPTION
## Summary
- Lowered `EASY.acceptanceThreshold` from `0.50f` to `0.35f` to make beginner mode more forgiving
- Added doc comments to each `Difficulty` enum entry explaining what the threshold represents

## Changes
- `Difficulty.kt`: Updated EASY threshold and added documentation comments

## Verification
- Easy mode will now accept chords with mediocre technique (confidence >= 0.35)
- Medium and Hard modes remain unchanged
- The `confidenceToFeedback()` thresholds (0.90, 0.70) still produce sensible feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)