### PR TITLE
Fix selection state lost when switching chord filters

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryViewModel.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/screen/library/ChordLibraryViewModel.kt
@@ -98,10 +98,7 @@ class ChordLibraryViewModel @Inject constructor(
         viewModelScope.launch {
             groupsRepository.deleteGroup(group.id)
             groupFilter.value = null
-            _uiState.value = _uiState.value.copy(
-                deleteConfirmGroup = null,
-                selectedChordIds = emptySet()
-            )
+            _uiState.value = _uiState.value.copy(deleteConfirmGroup = null)
         }
     }
 
@@ -154,8 +151,11 @@ class ChordLibraryViewModel @Inject constructor(
     }
 
     fun selectAll() {
-        val ids = _uiState.value.filteredChords.map { it.id }.toSet()
-        _uiState.value = _uiState.value.copy(selectedChordIds = ids)
+        val toAdd = _uiState.value.filteredChords.map { it.id }.toSet()
+        if (toAdd.isEmpty()) return
+        _uiState.value = _uiState.value.copy(
+            selectedChordIds = _uiState.value.selectedChordIds + toAdd
+        )
     }
 
     fun clearSelection() {


### PR DESCRIPTION
## Summary

- `selectAll()` now unions filtered chords into the existing selection instead of replacing it, preserving selections from other filter views
- `confirmDeleteGroup()` no longer clears `selectedChordIds` — deleting a filter group has no relationship to the user's chord selections

Fixes #176

## Test plan

- [ ] Select a chord in one filter view, switch to another filter view — selection count persists
- [ ] Tap "All" in a filter — adds to existing selections (union), does not replace
- [ ] Tap "All" again on same filter — count unchanged (idempotent)
- [ ] Tap "None" — clears all selections across all filters
- [ ] Delete a custom group — selection count and badges unchanged
- [ ] Tap "Start →" from a filtered view with chords selected in other filters — all selected chords appear in the quiz

https://claude.ai/code/session_01Ev474UAw1qVeh74Re8AuSK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ev474UAw1qVeh74Re8AuSK)_