### PR TITLE
Fix final note in results score sequence not playing audio

### DIFF
--- a/app/src/main/java/com/chordquiz/app/ui/components/staff/MusicalGradeStaff.kt
+++ b/app/src/main/java/com/chordquiz/app/ui/components/staff/MusicalGradeStaff.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.chordquiz.app.audio.NotePlayer
 import com.chordquiz.app.domain.semitoneToDiatonic
 import kotlin.math.roundToInt
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 /** Nine quarter-notes spanning from E4 (bottom treble line) to F5 (top treble line). */
@@ -85,13 +86,17 @@ fun MusicalGradeStaff(
 
     LaunchedEffect(targetFilled) {
         animatable.snapTo(0f)
-        for (i in 0 until targetFilled) {
-            // Fire audio concurrently with the visual animation for this note.
-            launch { NotePlayer.playNote(GRADE_NOTES[i].midi, instrumentId, durationMs = 400) }
-            animatable.animateTo(
-                targetValue = (i + 1).toFloat(),
-                animationSpec = tween(durationMillis = 350)
-            )
+        // coroutineScope ensures all launched audio jobs (including the final note)
+        // complete before the block exits, preventing the last note from being cancelled.
+        coroutineScope {
+            for (i in 0 until targetFilled) {
+                // Fire audio concurrently with the visual animation for this note.
+                launch { NotePlayer.playNote(GRADE_NOTES[i].midi, instrumentId, durationMs = 400) }
+                animatable.animateTo(
+                    targetValue = (i + 1).toFloat(),
+                    animationSpec = tween(durationMillis = 350)
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- The last note in the `MusicalGradeStaff` scoring animation was silent because the `LaunchedEffect` block returned immediately after the final `animateTo` (350 ms), cancelling the last note's audio coroutine before it could finish its 400 ms `NotePlayer.playNote` call.
- Wrapped the animation loop in `coroutineScope { }` so the block doesn't exit until all launched audio jobs — including the final note — have fully completed.

## Test plan

- [ ] Navigate to the results screen after completing any quiz
- [ ] Confirm all notes in the scoring staff play audio sequentially, including the final note
- [ ] Verify the visual fill animation is unchanged (notes still light up one by one)
- [ ] Test across multiple score values (low, mid, high) to confirm the correct number of notes play

https://claude.ai/code/session_01Ry5uo3t5uCrjxf9MCJrxqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry5uo3t5uCrjxf9MCJrxqx)_