### PR TITLE
Add backup and data extraction rules for database persistence

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <application
         android:name=".ChordQuizApplication"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/chordquiz/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/chordquiz/app/di/DatabaseModule.kt
@@ -87,6 +87,7 @@ object DatabaseModule {
             ChordQuizDatabase::class.java,
             "chord_quiz.db"
         ).addMigrations(MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
             .addCallback(callback)
             .build()
             .also { database = it }

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="database" path="chord_quiz.db"/>
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <include domain="database" path="chord_quiz.db"/>
+    </cloud-backup>
+    <device-transfer>
+        <include domain="database" path="chord_quiz.db"/>
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary
This PR adds Android backup and data extraction configuration to ensure the chord quiz database is properly backed up to cloud storage and transferred between devices.

## Key Changes
- **New file: `data_extraction_rules.xml`** - Configures cloud backup and device transfer rules to include the `chord_quiz.db` database
- **New file: `backup_rules.xml`** - Specifies full backup content rules to include the `chord_quiz.db` database
- **Updated `AndroidManifest.xml`** - Added `android:fullBackupContent` and `android:dataExtractionRules` attributes to the application element to reference the new backup configuration files
- **Updated `DatabaseModule.kt`** - Set Room database journal mode to `TRUNCATE` to improve compatibility with backup operations and reduce backup size

## Implementation Details
The backup configuration ensures that user quiz data and progress stored in the Room database is preserved during:
- Cloud backup operations (Android 12+)
- Device-to-device transfers
- Full backup operations (Android 11 and below)

The journal mode change from the default `WAL` (Write-Ahead Logging) to `TRUNCATE` reduces the number of files that need to be backed up and can improve backup performance while maintaining data integrity.

https://claude.ai/code/session_01J5p3NXbiGtuQFrLxg1UTgu